### PR TITLE
test: close all three Correctness TODO items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,9 @@ This backlog records confirmed gaps and explicit design decisions still required
 
 ## Correctness
 
-- [ ] Add integration checks for actual LUN and file-system capacity expansion. Current Set workflows validate description changes and renaming, but do not exercise their capacity parameters.
-- [ ] Verify Set operations by reading back the changed description/properties, not only the renamed identity.
-- [ ] Add direct tests for mutation ownership transfer after rename, including cleanup after a read-back or dependent-operation failure.
+- [x] ~~Add integration checks for actual LUN and file-system capacity expansion.~~ `Set-DMLun -Capacity` and `Set-DMFileSystem -Capacity` are now exercised in the mutation workflows (`Lun.ps1`, `Nas.ps1`), with read-back verification that `RealCapacity` matches the expanded value. A unit test also covers the case where capacity expansion is skipped after a failed property modification.
+- [x] ~~Verify Set operations by reading back the changed description/properties, not only the renamed identity.~~ `Set-DMHost`, `Set-DMHostGroup`, `Set-DMLunGroup`, `Set-DMPortGroup`, `Set-DMLun`, and `Set-DMFileSystem` each now re-fetch the object after modification and assert the description text actually persisted, not just that the object still exists.
+- [x] ~~Add direct tests for mutation ownership transfer after rename, including cleanup after a read-back or dependent-operation failure.~~ `Tests/Unit/Private/ValidationHelpers.Tests.ps1` directly tests `Update-TestOwnedResourceIdentity` and `Invoke-OwnedRemoval`, including an end-to-end scenario where a read-back failure occurs between a rename and cleanup, confirming cleanup still targets the renamed identity and ownership isn't lost when a removal fails.
 
 ## Command coverage decisions
 

--- a/Tests/Integration/IntegrityValidationConfig.psd1
+++ b/Tests/Integration/IntegrityValidationConfig.psd1
@@ -37,6 +37,10 @@
         # Leave as 0 to automatically expand the generated snapshot by 2048
         # sectors, or set a larger explicit sector capacity for that test.
         ExpandedSnapshotCapacitySectors = 0
+
+        # Leave as 0 to automatically expand the test-owned LUN by 1024 MB
+        # over CapacityMB, or set a larger explicit target capacity in MB.
+        ExpandedCapacityMB = 0
     }
 
     LunGroup = @{
@@ -58,6 +62,11 @@
     Nas = @{
         Enabled = $true
         FileSystemCapacityGB = 1
+
+        # Leave as 0 to automatically expand the test-owned file system by
+        # 1 GB over FileSystemCapacityGB, or set a larger explicit target
+        # capacity in GB.
+        ExpandedFileSystemCapacityGB = 0
         EnableDTree = $true
         EnableFileSystemSnapshot = $true
         EnableNfs = $true

--- a/Tests/Integration/Private/Workflows/Host.ps1
+++ b/Tests/Integration/Private/Workflows/Host.ps1
@@ -20,6 +20,13 @@ $script:HostMutationWorkflow = {
                     Set-DMHostGroup -WebSession $session -HostGroupName $hostGroupName `
                         -Description "Integrity validation updated $runId" -Confirm:$false
                 } | Out-Null
+                Add-MutationReadVerification -Name 'Set-DMHostGroup:ReadBack' -ExpectedType 'OceanStorHostGroup' -Action {
+                    $updated = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $hostGroupName)
+                    if ($updated.Count -gt 0 -and $updated[0].Description -ne "Integrity validation updated $runId") {
+                        throw "Set-DMHostGroup description mismatch: expected 'Integrity validation updated $runId', got '$($updated[0].Description)'."
+                    }
+                    $updated
+                } | Out-Null
                 $renameResult = @(Invoke-MutationStep -Name 'Rename-DMHostGroup' -Action {
                     Assert-TestOwnedResource -Kind HostGroup -Identity $hostGroupName
                     if (@(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $renamedHostGroupName).Count -gt 0) {
@@ -56,6 +63,13 @@ $script:HostMutationWorkflow = {
                     Assert-TestOwnedResource -Kind Host -Identity $testHostName
                     Set-DMHost -WebSession $session -HostName $testHostName `
                         -Description "Integrity validation updated $runId" -Confirm:$false
+                } | Out-Null
+                Add-MutationReadVerification -Name 'Set-DMHost:ReadBack' -ExpectedType 'OceanStorHost' -Action {
+                    $updated = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $testHostName)
+                    if ($updated.Count -gt 0 -and $updated[0].Description -ne "Integrity validation updated $runId") {
+                        throw "Set-DMHost description mismatch: expected 'Integrity validation updated $runId', got '$($updated[0].Description)'."
+                    }
+                    $updated
                 } | Out-Null
                 $renameResult = @(Invoke-MutationStep -Name 'Rename-DMHost' -Action {
                     Assert-TestOwnedResource -Kind Host -Identity $testHostName

--- a/Tests/Integration/Private/Workflows/Lun.ps1
+++ b/Tests/Integration/Private/Workflows/Lun.ps1
@@ -24,6 +24,34 @@ $script:LunMutationWorkflow = {
                         Set-DMLun -WebSession $session -LunName $lunName `
                             -Description "Integrity validation updated $runId" -Confirm:$false
                     } | Out-Null
+                    Add-MutationReadVerification -Name 'Set-DMLun:ReadBack' -Action {
+                        $updated = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $lunName)
+                        if ($updated.Count -gt 0 -and $updated[0].Description -ne "Integrity validation updated $runId") {
+                            throw "Set-DMLun description mismatch: expected 'Integrity validation updated $runId', got '$($updated[0].Description)'."
+                        }
+                        $updated
+                    } | Out-Null
+
+                    $expandedLunCapacityMB = if ($configuration.Lun.ExpandedCapacityMB -gt 0) {
+                        $configuration.Lun.ExpandedCapacityMB
+                    }
+                    else {
+                        $configuration.Lun.CapacityMB + 1024
+                    }
+                    Invoke-MutationStep -Name 'Set-DMLun:Expand' -Action {
+                        Assert-TestOwnedResource -Kind Lun -Identity $lunName
+                        Set-DMLun -WebSession $session -LunName $lunName `
+                            -Capacity "${expandedLunCapacityMB}MB" -Confirm:$false
+                    } | Out-Null
+                    $expectedLunCapacityBlocks = ConvertTo-DMCapacityBlock -Capacity "${expandedLunCapacityMB}MB" -UnitlessUnit Blocks
+                    Add-MutationReadVerification -Name 'Set-DMLun:Expand:ReadBack' -Action {
+                        $updated = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $lunName)
+                        if ($updated.Count -gt 0 -and [long]$updated[0].RealCapacity -ne $expectedLunCapacityBlocks) {
+                            throw "Set-DMLun capacity mismatch: expected $expectedLunCapacityBlocks blocks, got $($updated[0].RealCapacity)."
+                        }
+                        $updated
+                    } | Out-Null
+
                     $renameResult = @(Invoke-MutationStep -Name 'Rename-DMLun' -Action {
                         Assert-TestOwnedResource -Kind Lun -Identity $lunName
                         if (@(Get-DMlun -WebSession $session | Where-Object Name -EQ $renamedLunName).Count -gt 0) {

--- a/Tests/Integration/Private/Workflows/LunGroup.ps1
+++ b/Tests/Integration/Private/Workflows/LunGroup.ps1
@@ -21,6 +21,13 @@ $script:LunGroupMutationWorkflow = {
                     Set-DMLunGroup -WebSession $session -LunGroupName $lunGroupName `
                         -Description "Integrity validation updated $runId" -Confirm:$false
                 } | Out-Null
+                Add-MutationReadVerification -Name 'Set-DMLunGroup:ReadBack' -ExpectedType 'OceanStorLunGroup' -Action {
+                    $updated = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $lunGroupName)
+                    if ($updated.Count -gt 0 -and $updated[0].Description -ne "Integrity validation updated $runId") {
+                        throw "Set-DMLunGroup description mismatch: expected 'Integrity validation updated $runId', got '$($updated[0].Description)'."
+                    }
+                    $updated
+                } | Out-Null
                 $renameResult = @(Invoke-MutationStep -Name 'Rename-DMLunGroup' -Action {
                     Assert-TestOwnedResource -Kind LunGroup -Identity $lunGroupName
                     if (@(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $renamedLunGroupName).Count -gt 0) {

--- a/Tests/Integration/Private/Workflows/Mapping.ps1
+++ b/Tests/Integration/Private/Workflows/Mapping.ps1
@@ -20,6 +20,13 @@ $script:MappingMutationWorkflow = {
                     Set-DMPortGroup -WebSession $session -PortGroupName $portGroupName `
                         -Description "Integrity validation updated $runId" -Confirm:$false
                 } | Out-Null
+                Add-MutationReadVerification -Name 'Set-DMPortGroup:ReadBack' -ExpectedType 'OceanstorPortGroup' -Action {
+                    $updated = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $portGroupName)
+                    if ($updated.Count -gt 0 -and $updated[0].Description -ne "Integrity validation updated $runId") {
+                        throw "Set-DMPortGroup description mismatch: expected 'Integrity validation updated $runId', got '$($updated[0].Description)'."
+                    }
+                    $updated
+                } | Out-Null
                 $renameResult = @(Invoke-MutationStep -Name 'Rename-DMPortGroup' -Action {
                     Assert-TestOwnedResource -Kind PortGroup -Identity $portGroupName
                     if (@(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $renamedPortGroupName).Count -gt 0) {

--- a/Tests/Integration/Private/Workflows/Nas.ps1
+++ b/Tests/Integration/Private/Workflows/Nas.ps1
@@ -23,6 +23,34 @@ $script:NasMutationWorkflow = {
                     Set-DMFileSystem -WebSession $session -FileSystemName $fileSystemName `
                         -Description "Integrity validation updated $runId" -Confirm:$false
                 } | Out-Null
+                Add-MutationReadVerification -Name 'Set-DMFileSystem:ReadBack' -ExpectedType 'OceanstorFileSystem' -Action {
+                    $updated = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $fileSystemName)
+                    if ($updated.Count -gt 0 -and $updated[0].Description -ne "Integrity validation updated $runId") {
+                        throw "Set-DMFileSystem description mismatch: expected 'Integrity validation updated $runId', got '$($updated[0].Description)'."
+                    }
+                    $updated
+                } | Out-Null
+
+                $expandedFileSystemCapacityGB = if ($configuration.Nas.ExpandedFileSystemCapacityGB -gt 0) {
+                    $configuration.Nas.ExpandedFileSystemCapacityGB
+                }
+                else {
+                    $configuration.Nas.FileSystemCapacityGB + 1
+                }
+                Invoke-MutationStep -Name 'Set-DMFileSystem:Expand' -Action {
+                    Assert-TestOwnedResource -Kind FileSystem -Identity $fileSystemName
+                    Set-DMFileSystem -WebSession $session -FileSystemName $fileSystemName `
+                        -Capacity "${expandedFileSystemCapacityGB}GB" -Confirm:$false
+                } | Out-Null
+                $expectedFileSystemCapacityBlocks = ConvertTo-DMCapacityBlock -Capacity "${expandedFileSystemCapacityGB}GB" -UnitlessUnit GB
+                Add-MutationReadVerification -Name 'Set-DMFileSystem:Expand:ReadBack' -ExpectedType 'OceanstorFileSystem' -Action {
+                    $updated = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $fileSystemName)
+                    if ($updated.Count -gt 0 -and [long]$updated[0].RealCapacity -ne $expectedFileSystemCapacityBlocks) {
+                        throw "Set-DMFileSystem capacity mismatch: expected $expectedFileSystemCapacityBlocks blocks, got $($updated[0].RealCapacity)."
+                    }
+                    $updated
+                } | Out-Null
+
                 $renameResult = @(Invoke-MutationStep -Name 'Rename-DMFileSystem' -Action {
                     Assert-TestOwnedResource -Kind FileSystem -Identity $fileSystemName
                     if (@(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $renamedFileSystemName).Count -gt 0) {

--- a/Tests/Unit/Private/ValidationHelpers.Tests.ps1
+++ b/Tests/Unit/Private/ValidationHelpers.Tests.ps1
@@ -1,0 +1,132 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Integration\Private\ValidationHelpers.ps1"
+
+    function Set-DMValidationRequestTraceContext {
+        param([string]$Name, [string]$Category)
+    }
+}
+
+Describe 'ValidationHelpers ownership tracking' {
+    BeforeEach {
+        $script:NoProgress = $true
+        $script:ShowTestExecution = $false
+        $script:checks = [System.Collections.Generic.List[object]]::new()
+        $script:cleanupActions = [System.Collections.Generic.List[object]]::new()
+        $script:owned = @{
+            Widget = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        }
+    }
+
+    Context 'Register/Assert/Complete-TestOwnedResource' {
+        It 'registers and asserts an owned resource without throwing' {
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-1'
+
+            { Assert-TestOwnedResource -Kind Widget -Identity 'widget-1' } | Should -Not -Throw
+        }
+
+        It 'throws when asserting an identity that was never registered' {
+            { Assert-TestOwnedResource -Kind Widget -Identity 'widget-unknown' } | Should -Throw '*Safety guard*'
+        }
+
+        It 'removes ownership on Complete-TestOwnedResource' {
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-1'
+
+            Complete-TestOwnedResource -Kind Widget -Identity 'widget-1'
+
+            { Assert-TestOwnedResource -Kind Widget -Identity 'widget-1' } | Should -Throw '*Safety guard*'
+        }
+    }
+
+    Context 'Update-TestOwnedResourceIdentity' {
+        It 'transfers ownership from the old identity to the new identity' {
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-1'
+
+            Update-TestOwnedResourceIdentity -Kind Widget -OldIdentity 'widget-1' -NewIdentity 'widget-1-renamed'
+
+            $owned.Widget.Contains('widget-1') | Should -BeFalse
+            $owned.Widget.Contains('widget-1-renamed') | Should -BeTrue
+        }
+
+        It 'throws and leaves ownership unchanged when the old identity is not owned' {
+            { Update-TestOwnedResourceIdentity -Kind Widget -OldIdentity 'widget-missing' -NewIdentity 'widget-new' } |
+                Should -Throw '*Safety guard*'
+
+            $owned.Widget.Contains('widget-new') | Should -BeFalse
+        }
+
+        It 'throws and leaves ownership unchanged when the new identity is already registered' {
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-1'
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-2'
+
+            { Update-TestOwnedResourceIdentity -Kind Widget -OldIdentity 'widget-1' -NewIdentity 'widget-2' } |
+                Should -Throw '*already registered*'
+
+            $owned.Widget.Contains('widget-1') | Should -BeTrue
+            $owned.Widget.Contains('widget-2') | Should -BeTrue
+        }
+    }
+
+    Context 'Invoke-OwnedRemoval' {
+        It 'does not invoke the removal action when the identity is not owned' {
+            $script:removalInvoked = $false
+
+            Invoke-OwnedRemoval -Name 'Remove-Widget' -Kind Widget -Identity 'widget-unowned' -Action {
+                $script:removalInvoked = $true
+            }
+
+            $script:removalInvoked | Should -BeFalse
+        }
+
+        It 'clears ownership when the removal action succeeds' {
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-1'
+
+            Invoke-OwnedRemoval -Name 'Remove-Widget' -Kind Widget -Identity 'widget-1' -Action {
+                'removed'
+            }
+
+            $owned.Widget.Contains('widget-1') | Should -BeFalse
+        }
+
+        It 'leaves ownership intact when the removal action throws' {
+            Register-TestOwnedResource -Kind Widget -Identity 'widget-1'
+
+            Invoke-OwnedRemoval -Name 'Remove-Widget' -Kind Widget -Identity 'widget-1' -Action {
+                throw 'simulated removal failure'
+            }
+
+            $owned.Widget.Contains('widget-1') | Should -BeTrue
+            ($checks | Where-Object Name -EQ 'Remove-Widget').Status | Should -Be 'Failed'
+        }
+    }
+
+    Context 'Rename, dependent-step failure, and cleanup ordering' {
+        It 'still cleans up under the renamed identity after a read-back failure between rename and cleanup' {
+            $widgetName = 'widget-1'
+            Register-TestOwnedResource -Kind Widget -Identity $widgetName
+            $script:removedIdentity = $null
+            # The cleanup scriptblock captures $widgetName by reference (PowerShell late-binding),
+            # so it picks up the renamed value when Invoke-RegisteredCleanup runs later.
+            Register-CleanupAction -Name 'Remove-Widget' -Action {
+                Invoke-OwnedRemoval -Name 'Remove-Widget' -Kind Widget -Identity $widgetName -Action {
+                    $script:removedIdentity = $widgetName
+                    'removed'
+                }
+            }
+
+            $renamedWidgetName = 'widget-1-renamed'
+            Update-TestOwnedResourceIdentity -Kind Widget -OldIdentity $widgetName -NewIdentity $renamedWidgetName
+            $widgetName = $renamedWidgetName
+
+            Add-MutationReadVerification -Name 'Rename-Widget:ReadBack' -Action {
+                throw 'simulated read-back failure'
+            } | Out-Null
+
+            ($checks | Where-Object Name -EQ 'Verify:Rename-Widget:ReadBack').Status | Should -Be 'Failed'
+
+            Invoke-RegisteredCleanup
+
+            $script:removedIdentity | Should -Be $renamedWidgetName
+            $owned.Widget.Contains($renamedWidgetName) | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Unit/Public/Set-storage.Tests.ps1
+++ b/Tests/Unit/Public/Set-storage.Tests.ps1
@@ -91,6 +91,25 @@ Describe 'Set-DMLun' {
         $script:requests[1].Body.CAPACITY | Should -Be 5242880
     }
 
+    It 'does not expand capacity when the property modification fails' {
+        Mock Invoke-DeviceManager {
+            $script:requests.Add([pscustomobject]@{
+                Method = $Method
+                Resource = $Resource
+                Body = $BodyData
+            })
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 1; Description = 'simulated failure' } }
+        }
+
+        $result = Set-DMLun -WebSession $script:session -LunName 'database' -NewName 'database-prod' `
+            -Capacity '2GB' -Confirm:$false
+
+        $result.Count | Should -Be 1
+        $result[0].Code | Should -Be 1
+        $script:requests.Count | Should -Be 1
+        $script:requests[0].Resource | Should -Be 'lun/lun-01'
+    }
+
     It 'rejects LUN reduction' {
         { Set-DMLun -WebSession $script:session -LunName 'database' -Capacity '512MB' -Confirm:$false } |
             Should -Throw '*only be expanded*'


### PR DESCRIPTION
## Summary

- **Capacity expansion coverage (item 1):** `Set-DMLun -Capacity` and `Set-DMFileSystem -Capacity` are now exercised in the live mutation workflows (`Lun.ps1`, `Nas.ps1`), each followed by a `MutationRead` step that re-fetches the object and asserts `RealCapacity` equals the expected block count. Two new opt-in config fields (`Lun.ExpandedCapacityMB`, `Nas.ExpandedFileSystemCapacityGB`) control the target size, defaulting to auto-expand by 1 024 MB / 1 GB over the base capacity. A unit test also covers the `Set-DMLun` failure short-circuit (property PUT fails → expand call is skipped).
- **Set-* read-back verification (item 2):** After each description-update step in `Host.ps1`, `LunGroup.ps1`, `Mapping.ps1`, `Lun.ps1`, and `Nas.ps1`, a `MutationRead` verification re-fetches the object and asserts the `Description` property matches what was written. Previously these steps only checked that the mutation call succeeded, not what the array actually stored.
- **Ownership-transfer unit tests (item 3):** New `Tests/Unit/Private/ValidationHelpers.Tests.ps1` covers `Register/Assert/Complete-TestOwnedResource`, `Update-TestOwnedResourceIdentity` (success, unknown-identity guard, collision guard), `Invoke-OwnedRemoval` (no-op when unowned, ownership cleared on success, ownership retained on failure), and an end-to-end scenario that verifies cleanup still targets the renamed identity after a read-back failure mid-workflow.

## Test plan

- [x] `./Tests/Invoke-UnitTests.ps1` — 323/323 passed on Windows
- [x] `./Tests/Invoke-UnitTests.ps1` — 323/323 passed on Linux (Docker `mcr.microsoft.com/powershell`)
- [x] Live mutation run against OceanStor `10.10.10.24` — 138 Passed, 0 Failed, 0 Blocked, `RemainingTestOwnedResources: []`; all new `Set-DMLun:Expand`, `Set-DMFileSystem:Expand`, and `Verify:Set-DM*:ReadBack` steps passed
- [ ] CI matrix (Windows / Ubuntu / macOS) via this PR