### PR TITLE
fix: security, reliability, and quality hardening (v0.9.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Reports/
 temp-doc-*
 .codegraph/
 .vscode/
+ANALYSIS.md

--- a/POSH-Oceanstor/POSH-Oceanstor.psd1
+++ b/POSH-Oceanstor/POSH-Oceanstor.psd1
@@ -13,7 +13,7 @@
 RootModule = "posh-oceanstor.psm1"
 
 # Version number of this module.
-ModuleVersion = "0.9.4"
+ModuleVersion = "0.9.5"
 
 # ID used to uniquely identify this module
 GUID = "67f4a145-d50d-4c26-bd26-b1303fd48aa1"

--- a/POSH-Oceanstor/Private/Invoke-DMPagedRequest.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DMPagedRequest.ps1
@@ -1,0 +1,57 @@
+function Invoke-DMPagedRequest {
+    <#
+    .SYNOPSIS
+        Retrieves all pages of a collection resource from the OceanStor REST API.
+
+    .DESCRIPTION
+        Calls Invoke-DeviceManager in a loop, appending range=[start,end] query parameters
+        until the API returns fewer results than the requested page size, indicating the last
+        page has been reached. Returns the combined raw data array from all pages.
+
+        The OceanStor API returns at most PageSize objects per request when no range is
+        specified, silently truncating larger collections. This helper ensures every object
+        in a collection is retrieved regardless of size.
+
+    .PARAMETER WebSession
+        Optional session returned by Connect-deviceManager. The global deviceManager session
+        is used when omitted.
+
+    .PARAMETER Resource
+        REST resource path to page through. If the path already contains query parameters
+        (i.e. contains '?'), range parameters are appended with '&'; otherwise '?' is used.
+
+    .PARAMETER PageSize
+        Number of results to request per page. Defaults to 100, the OceanStor maximum per
+        single request.
+    #>
+    param(
+        [pscustomobject]$WebSession,
+
+        [Parameter(Mandatory)]
+        [string]$Resource,
+
+        [ValidateRange(1, 100)]
+        [int]$PageSize = 100
+    )
+
+    $allData = [System.Collections.Generic.List[object]]::new()
+    $start = 0
+    $separator = if ($Resource -match '\?') { '&' } else { '?' }
+
+    do {
+        $end = $start + $PageSize - 1
+        $pagedResource = "${Resource}${separator}range=[$start,$end]"
+
+        $response = Invoke-DeviceManager -WebSession $WebSession -Method 'GET' -Resource $pagedResource
+        $dataProperty = if ($null -ne $response) { $response.PSObject.Properties['data'] } else { $null }
+        $page = if ($null -ne $dataProperty) { @($dataProperty.Value) } else { @() }
+
+        foreach ($item in $page) {
+            $allData.Add($item)
+        }
+
+        $start += $PageSize
+    } while ($page.Count -eq $PageSize)
+
+    return $allData.ToArray()
+}

--- a/POSH-Oceanstor/Private/Invoke-DMPagedRequest.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DMPagedRequest.ps1
@@ -43,6 +43,10 @@ function Invoke-DMPagedRequest {
         $pagedResource = "${Resource}${separator}range=[$start,$end]"
 
         $response = Invoke-DeviceManager -WebSession $WebSession -Method 'GET' -Resource $pagedResource
+        $errorProperty = if ($null -ne $response) { $response.PSObject.Properties['error'] } else { $null }
+        if ($null -ne $errorProperty -and $errorProperty.Value.Code -ne 0) {
+            throw "OceanStor API error $($errorProperty.Value.Code) for resource '$pagedResource': $($errorProperty.Value.description)"
+        }
         $dataProperty = if ($null -ne $response) { $response.PSObject.Properties['data'] } else { $null }
         $page = if ($null -ne $dataProperty) { @($dataProperty.Value) } else { @() }
 

--- a/POSH-Oceanstor/Private/Invoke-DMPagedRequest.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DMPagedRequest.ps1
@@ -45,6 +45,15 @@ function Invoke-DMPagedRequest {
         $response = Invoke-DeviceManager -WebSession $WebSession -Method 'GET' -Resource $pagedResource
         $errorProperty = if ($null -ne $response) { $response.PSObject.Properties['error'] } else { $null }
         if ($null -ne $errorProperty -and $errorProperty.Value.Code -ne 0) {
+            if ($start -eq 0 -and $errorProperty.Value.Code -eq 50331651) {
+                $response = Invoke-DeviceManager -WebSession $WebSession -Method 'GET' -Resource $Resource
+                $errorProperty = if ($null -ne $response) { $response.PSObject.Properties['error'] } else { $null }
+                if ($null -eq $errorProperty -or $errorProperty.Value.Code -eq 0) {
+                    $dataProperty = if ($null -ne $response) { $response.PSObject.Properties['data'] } else { $null }
+                    $fallbackPage = if ($null -ne $dataProperty) { @($dataProperty.Value) } else { @() }
+                    return $fallbackPage
+                }
+            }
             throw "OceanStor API error $($errorProperty.Value.Code) for resource '$pagedResource': $($errorProperty.Value.description)"
         }
         $dataProperty = if ($null -ne $response) { $response.PSObject.Properties['data'] } else { $null }

--- a/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
@@ -147,12 +147,23 @@ function Invoke-DeviceManager{
 
 	$startedAt = Get-Date
 	try {
+		# Preserve the certificate validation choice made when the session was created.
+		$invokeParams = @{
+			Method      = $Method
+			Uri         = $RestURI
+			Headers     = $session.Headers
+			WebSession  = $session.WebSession
+			ContentType = 'application/json'
+		}
+		if ($session.SkipCertificateCheck) {
+			$invokeParams.SkipCertificateCheck = $true
+		}
+
 		if ($BodyData){
 			$JsonBody = ConvertTo-Json $BodyData
-			$result = Invoke-RestMethod -Method $Method -uri $RestURI -Headers $session.Headers -WebSession $session.WebSession -ContentType "application/json" -SkipCertificateCheck -Body $JsonBody
-		} else {
-			$result = Invoke-RestMethod -Method $Method -uri $RestURI -Headers $session.Headers -WebSession $session.WebSession -ContentType "application/json" -SkipCertificateCheck
+			$invokeParams.Body = $JsonBody
 		}
+		$result = Invoke-RestMethod @invokeParams
 
 		Write-DMRequestTrace -StartedAt $startedAt -Method $Method -Resource $Resource -Uri $RestURI `
 			-BodyData $BodyData -ApiV2:$ApiV2 -Response $result

--- a/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
@@ -1,3 +1,32 @@
+function ConvertFrom-DMCasedHashtable {
+    # Recursively converts a Hashtable (e.g. from ConvertFrom-Json -AsHashtable) to PSCustomObject,
+    # deduplicating case-conflicting keys by preferring the all-uppercase variant.
+    param([object]$InputObject)
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        $seen   = @{}
+        $result = [ordered]@{}
+        foreach ($key in @($InputObject.Keys)) {
+            $lower = $key.ToLowerInvariant()
+            if ($seen.ContainsKey($lower)) {
+                if ($key -ceq $key.ToUpperInvariant()) {
+                    $existing = $seen[$lower]
+                    $result.Remove($existing)
+                    $result[$key] = ConvertFrom-DMCasedHashtable $InputObject[$key]
+                    $seen[$lower] = $key
+                }
+            } else {
+                $seen[$lower] = $key
+                $result[$key] = ConvertFrom-DMCasedHashtable $InputObject[$key]
+            }
+        }
+        return [pscustomobject]$result
+    }
+    if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject -isnot [string]) {
+        return @($InputObject | ForEach-Object { ConvertFrom-DMCasedHashtable $_ })
+    }
+    return $InputObject
+}
+
 function Copy-DMTraceValue {
 	param(
 		[Parameter(ValueFromPipeline = $true)]
@@ -170,8 +199,24 @@ function Invoke-DeviceManager{
 		return $result
 	}
 	catch {
+		$originalError = $_
+		# Some OceanStor endpoints return JSON bodies with the same key in different cases
+		# (e.g. "snapType" and "SNAPTYPE"). Invoke-RestMethod cannot parse these; fall back
+		# to Invoke-WebRequest + ConvertFrom-Json -AsHashtable, which uses a case-sensitive
+		# hashtable, then normalize to a PSCustomObject preferring the uppercase key.
+		if ($_.Exception.Message -like '*keys with different casing*') {
+			try {
+				$rawResponse = Invoke-WebRequest @invokeParams
+				$result = ConvertFrom-DMCasedHashtable ($rawResponse.Content | ConvertFrom-Json -AsHashtable)
+				Write-DMRequestTrace -StartedAt $startedAt -Method $Method -Resource $Resource -Uri $RestURI `
+					-BodyData $BodyData -ApiV2:$ApiV2 -Response $result
+				return $result
+			} catch {
+				Write-Verbose "Invoke-WebRequest fallback also failed for '$RestURI': $($_.Exception.Message)"
+			}
+		}
 		Write-DMRequestTrace -StartedAt $startedAt -Method $Method -Resource $Resource -Uri $RestURI `
-			-BodyData $BodyData -ApiV2:$ApiV2 -Exception $_.Exception.Message
-		throw
+			-BodyData $BodyData -ApiV2:$ApiV2 -Exception $originalError.Exception.Message
+		throw $originalError
 	}
 }

--- a/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
@@ -194,6 +194,18 @@ function Invoke-DeviceManager{
 		}
 		$result = Invoke-RestMethod @invokeParams
 
+		# Some PS7 builds fall back to returning the raw JSON string instead of throwing when
+		# the response body contains case-conflicting duplicate keys (e.g. 'snapType'/'SNAPTYPE'
+		# on the fssnapshot endpoint). Convert to PSCustomObject using the case-aware helper so
+		# callers always receive a consistent object type.
+		if ($result -is [string] -and $result) {
+			try {
+				$result = ConvertFrom-DMCasedHashtable ($result | ConvertFrom-Json -AsHashtable)
+			} catch {
+				Write-Verbose "String response from '$RestURI' could not be re-parsed: $($_.Exception.Message)"
+			}
+		}
+
 		Write-DMRequestTrace -StartedAt $startedAt -Method $Method -Resource $Resource -Uri $RestURI `
 			-BodyData $BodyData -ApiV2:$ApiV2 -Response $result
 		return $result

--- a/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
@@ -135,6 +135,10 @@ function Invoke-DeviceManager{
         $session = $deviceManager
     }
 
+    if ($null -eq $session) {
+        throw 'No OceanStor session available. Call Connect-deviceManager first, or pass a session via -WebSession.'
+    }
+
 	if ($ApiV2) {
 		$RestURI = "https://$($session.hostname):8088/api/v2/$resource"
 	} else {

--- a/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
+++ b/POSH-Oceanstor/Private/Invoke-DeviceManager.ps1
@@ -204,7 +204,15 @@ function Invoke-DeviceManager{
 		# (e.g. "snapType" and "SNAPTYPE"). Invoke-RestMethod cannot parse these; fall back
 		# to Invoke-WebRequest + ConvertFrom-Json -AsHashtable, which uses a case-sensitive
 		# hashtable, then normalize to a PSCustomObject preferring the uppercase key.
-		if ($_.Exception.Message -like '*keys with different casing*') {
+		# PS7 may surface the duplicate-key parse error in different ways depending on version.
+		# Check the FullyQualifiedErrorId (most stable), the exception message, and the full
+		# ErrorRecord string representation as a belt-and-suspenders guard.
+		$isDuplicateKeyParseError = (
+			$_.FullyQualifiedErrorId -like '*CannotConvertContent*' -or
+			$_.Exception.Message     -like '*keys with different casing*' -or
+			"$_"                     -like '*keys with different casing*'
+		)
+		if ($isDuplicateKeyParseError) {
 			try {
 				$rawResponse = Invoke-WebRequest @invokeParams
 				$result = ConvertFrom-DMCasedHashtable ($rawResponse.Content | ConvertFrom-Json -AsHashtable)

--- a/POSH-Oceanstor/Private/Select-DMResponseData.ps1
+++ b/POSH-Oceanstor/Private/Select-DMResponseData.ps1
@@ -1,0 +1,20 @@
+function Select-DMResponseData {
+    # Pipeline helper: throws a descriptive error when the OceanStor API returns a
+    # non-zero error code, otherwise returns the .data payload. Replaces the bare
+    # '| Select-Object -ExpandProperty data' pattern used in Get-DM* commands so
+    # callers see the API error message instead of 'Cannot expand property data'.
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(ValueFromPipeline)]
+        [object]$Response
+    )
+    process {
+        if ($null -eq $Response) { return }
+        $errorProp = $Response.PSObject.Properties['error']
+        if ($null -ne $errorProp -and $errorProp.Value.Code -ne 0) {
+            throw "OceanStor API error $($errorProp.Value.Code): $($errorProp.Value.description)"
+        }
+        return $Response.data
+    }
+}

--- a/POSH-Oceanstor/Private/class-OceanstorLunv6.ps1
+++ b/POSH-Oceanstor/Private/class-OceanstorLunv6.ps1
@@ -244,9 +244,9 @@ class OceanstorLunv6{
 		$this.{Workload Type Id} = $lunReceived.WORKLOADTYPEID
 
 		if ($lunReceived.WORKLOADTYPEID){
-			$this.{Workload Type Name} = "invalid"
-		} else {
 			$this.{Workload Type Name} = $lunReceived.WORKLOADTYPENAME
+		} else {
+			$this.{Workload Type Name} = $null
 		}
 
 		$this.{Takeover Lun WWN} = $lunReceived.takeOverLunWwn
@@ -376,7 +376,9 @@ class OceanstorLunv6{
 	[psobject] Rename([string]$NewName)
 	{
 		$result = Rename-DMLun -WebSession $this.Session -LunName $this.Name -NewName $NewName -Confirm:$false
-		if ($result.Code -eq 0) {
+		# Rename-DMLun delegates to Set-DMLun which returns List[object]; index [0] to reach the error object.
+		# Indexing a plain PSCustomObject with [0] returns the object itself, so this is safe in both cases.
+		if ($result[0].Code -eq 0) {
 			$this.Name = $NewName
 		}
 		return $result

--- a/POSH-Oceanstor/Private/class-OceanstorSession.ps1
+++ b/POSH-Oceanstor/Private/class-OceanstorSession.ps1
@@ -21,6 +21,9 @@ class OceanstorSession{
 	#Define iBaseToken Property
 	hidden [string]$iBaseToken
 
+	#Define TLS validation compatibility switch
+	hidden [bool]$SkipCertificateCheck
+
 	#Define Software Version
 	[string]$Version
 

--- a/POSH-Oceanstor/Private/class-OceanstorSession.ps1
+++ b/POSH-Oceanstor/Private/class-OceanstorSession.ps1
@@ -18,9 +18,6 @@ class OceanstorSession{
 	#Define Headers Array Property
 	hidden [System.Collections.IDictionary]$Headers
 
-	#Define iBaseToken Property
-	hidden [string]$iBaseToken
-
 	#Define TLS validation compatibility switch
 	hidden [bool]$SkipCertificateCheck
 
@@ -40,7 +37,6 @@ class OceanstorSession{
         $this.Session = $WebSession
 		$this.WebSession = $WebSession
         $this.Headers = $SessionHeader
-        $this.iBaseToken = $logonsession.data.iBaseToken
         #$this.Credentials = $credentials
         $this.Hostname = $hostname
     }

--- a/POSH-Oceanstor/Public/Add-DMHostGroupToMappingView.ps1
+++ b/POSH-Oceanstor/Public/Add-DMHostGroupToMappingView.ps1
@@ -101,7 +101,9 @@ function Add-DMHostGroupToMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     $group = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $HostGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $body = @{ TYPE = 245; ID = $view.Id; ASSOCIATEOBJTYPE = 14; ASSOCIATEOBJID = $group.Id }
     if ($VstoreId) {
         $body.vstoreId = $VstoreId

--- a/POSH-Oceanstor/Public/Add-DMHostToHostGroup.ps1
+++ b/POSH-Oceanstor/Public/Add-DMHostToHostGroup.ps1
@@ -113,7 +113,9 @@ function Add-DMHostToHostGroup {
         $deviceManager
     }
     $hostObject = @($script:_dmAddHostHosts | Where-Object Name -EQ $HostName)[0]
+    if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
     $group = @($script:_dmAddHostGroups | Where-Object Name -EQ $HostGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $body = @{
         ID               = $group.Id
         ASSOCIATEOBJTYPE = 21

--- a/POSH-Oceanstor/Public/Add-DMHostToHostGroup.ps1
+++ b/POSH-Oceanstor/Public/Add-DMHostToHostGroup.ps1
@@ -50,15 +50,15 @@ function Add-DMHostToHostGroup {
                 else {
                     $deviceManager
                 }
-                $hosts = @(Get-DMhost -WebSession $session)
-                $matchingItems = @($hosts | Where-Object Name -EQ $candidate)
+                $script:_dmAddHostHosts = @(Get-DMhost -WebSession $session)
+                $matchingItems = @($script:_dmAddHostHosts | Where-Object Name -EQ $candidate)
                 if ($matchingItems.Count -eq 1) {
                     return $true
                 }
                 if ($matchingItems.Count -gt 1) {
                     throw "HostName is ambiguous because more than one host is named '$candidate'."
                 }
-                throw "Invalid HostName. Valid values are: $($hosts.Name -join ', ')"
+                throw "Invalid HostName. Valid values are: $($script:_dmAddHostHosts.Name -join ', ')"
             })]
         [ArgumentCompleter({
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
@@ -81,15 +81,15 @@ function Add-DMHostToHostGroup {
                 else {
                     $deviceManager
                 }
-                $groups = @(Get-DMhostGroup -WebSession $session)
-                $matchingItems = @($groups | Where-Object Name -EQ $candidate)
+                $script:_dmAddHostGroups = @(Get-DMhostGroup -WebSession $session)
+                $matchingItems = @($script:_dmAddHostGroups | Where-Object Name -EQ $candidate)
                 if ($matchingItems.Count -eq 1) {
                     return $true
                 }
                 if ($matchingItems.Count -gt 1) {
                     throw "HostGroupName is ambiguous because more than one host group is named '$candidate'."
                 }
-                throw "Invalid HostGroupName. Valid values are: $($groups.Name -join ', ')"
+                throw "Invalid HostGroupName. Valid values are: $($script:_dmAddHostGroups.Name -join ', ')"
             })]
         [ArgumentCompleter({
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
@@ -112,8 +112,8 @@ function Add-DMHostToHostGroup {
     else {
         $deviceManager
     }
-    $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
-    $group = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $HostGroupName)[0]
+    $hostObject = @($script:_dmAddHostHosts | Where-Object Name -EQ $HostName)[0]
+    $group = @($script:_dmAddHostGroups | Where-Object Name -EQ $HostGroupName)[0]
     $body = @{
         ID               = $group.Id
         ASSOCIATEOBJTYPE = 21

--- a/POSH-Oceanstor/Public/Add-DMLunGroupToMappingView.ps1
+++ b/POSH-Oceanstor/Public/Add-DMLunGroupToMappingView.ps1
@@ -111,10 +111,12 @@ function Add-DMLunGroupToMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     if (-not $view) {
         throw "Mapping view '$MappingViewName' was not found."
     }
     $group = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     if (-not $group) {
         throw "LUN group '$LunGroupName' was not found."
     }

--- a/POSH-Oceanstor/Public/Add-DMLunToLunGroup.ps1
+++ b/POSH-Oceanstor/Public/Add-DMLunToLunGroup.ps1
@@ -156,7 +156,9 @@ function Add-DMLunToLunGroup {
     }
 
     $lun = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $resolvedLunName)[0]
+    if ($null -eq $lun) { throw "Could not resolve 'lun' — the object may have been removed since parameter validation." }
     $group = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $body = @{
         ID               = $group.Id
         ASSOCIATEOBJTYPE = 11

--- a/POSH-Oceanstor/Public/Add-DMPortGroupToMappingView.ps1
+++ b/POSH-Oceanstor/Public/Add-DMPortGroupToMappingView.ps1
@@ -111,10 +111,12 @@ function Add-DMPortGroupToMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     if (-not $view) {
         throw "Mapping view '$MappingViewName' was not found."
     }
     $group = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $PortGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     if (-not $group) {
         throw "Port group '$PortGroupName' was not found."
     }

--- a/POSH-Oceanstor/Public/Add-DMPortToPortGroup.ps1
+++ b/POSH-Oceanstor/Public/Add-DMPortToPortGroup.ps1
@@ -124,7 +124,9 @@ function Add-DMPortToPortGroup {
         $deviceManager
     }
     $group = @($script:_dmAddPortGroups | Where-Object Name -EQ $PortGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $port = @($script:_dmAddPorts | Where-Object Name -EQ $PortName)[0]
+    if ($null -eq $port) { throw "Could not resolve 'port' — the object may have been removed since parameter validation." }
     $body = @{
         ID               = $group.Id
         ASSOCIATEOBJTYPE = $port.ObjectType

--- a/POSH-Oceanstor/Public/Add-DMPortToPortGroup.ps1
+++ b/POSH-Oceanstor/Public/Add-DMPortToPortGroup.ps1
@@ -53,15 +53,15 @@ function Add-DMPortToPortGroup {
                 else {
                     $deviceManager
                 }
-                $groups = @(Get-DMPortGroup -WebSession $session)
-                $matchingItems = @($groups | Where-Object Name -EQ $candidate)
+                $script:_dmAddPortGroups = @(Get-DMPortGroup -WebSession $session)
+                $matchingItems = @($script:_dmAddPortGroups | Where-Object Name -EQ $candidate)
                 if ($matchingItems.Count -eq 1) {
                     return $true
                 }
                 if ($matchingItems.Count -gt 1) {
                     throw "PortGroupName is ambiguous because more than one port group is named '$candidate'."
                 }
-                throw "Invalid PortGroupName. Valid values are: $($groups.Name -join ', ')"
+                throw "Invalid PortGroupName. Valid values are: $($script:_dmAddPortGroups.Name -join ', ')"
             })]
         [ArgumentCompleter({
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
@@ -88,15 +88,15 @@ function Add-DMPortToPortGroup {
                 else {
                     $deviceManager
                 }
-                $ports = @(Get-DMPortGroupCandidate -WebSession $session -PortType $PortType)
-                $matchingItems = @($ports | Where-Object Name -EQ $candidate)
+                $script:_dmAddPorts = @(Get-DMPortGroupCandidate -WebSession $session -PortType $PortType)
+                $matchingItems = @($script:_dmAddPorts | Where-Object Name -EQ $candidate)
                 if ($matchingItems.Count -eq 1) {
                     return $true
                 }
                 if ($matchingItems.Count -gt 1) {
                     throw "PortName is ambiguous because more than one $PortType port is named '$candidate'."
                 }
-                throw "Invalid PortName for $PortType. Valid values are: $($ports.Name -join ', ')"
+                throw "Invalid PortName for $PortType. Valid values are: $($script:_dmAddPorts.Name -join ', ')"
             })]
         [ArgumentCompleter({
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
@@ -123,8 +123,8 @@ function Add-DMPortToPortGroup {
     else {
         $deviceManager
     }
-    $group = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $PortGroupName)[0]
-    $port = @(Get-DMPortGroupCandidate -WebSession $session -PortType $PortType | Where-Object Name -EQ $PortName)[0]
+    $group = @($script:_dmAddPortGroups | Where-Object Name -EQ $PortGroupName)[0]
+    $port = @($script:_dmAddPorts | Where-Object Name -EQ $PortName)[0]
     $body = @{
         ID               = $group.Id
         ASSOCIATEOBJTYPE = $port.ObjectType

--- a/POSH-Oceanstor/Public/Connect-deviceManager.ps1
+++ b/POSH-Oceanstor/Public/Connect-deviceManager.ps1
@@ -110,8 +110,15 @@ function Connect-deviceManager {
         throw "Login failed for host '$Hostname': $($SessionError.description)"
     }
 
-    $CredentialsBytes = [System.Text.Encoding]::UTF8.GetBytes( -join ("{0}:{1}" -f $username, $password))
+    $CredentialsBytes   = [System.Text.Encoding]::UTF8.GetBytes( -join ("{0}:{1}" -f $username, $password))
     $EncodedCredentials = [Convert]::ToBase64String($CredentialsBytes)
+
+    # Wipe plaintext credentials from memory — they are no longer needed.
+    $username = $null
+    $password = $null
+    [Array]::Clear($CredentialsBytes, 0, $CredentialsBytes.Length)
+    $CredentialsBytes = $null
+    $body             = $null
 
     $SessionHeader = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
     $SessionHeader.Add("Authorization", "Basic $EncodedCredentials")

--- a/POSH-Oceanstor/Public/Connect-deviceManager.ps1
+++ b/POSH-Oceanstor/Public/Connect-deviceManager.ps1
@@ -110,18 +110,14 @@ function Connect-deviceManager {
         throw "Login failed for host '$Hostname': $($SessionError.description)"
     }
 
-    $CredentialsBytes   = [System.Text.Encoding]::UTF8.GetBytes( -join ("{0}:{1}" -f $username, $password))
-    $EncodedCredentials = [Convert]::ToBase64String($CredentialsBytes)
-
-    # Wipe plaintext credentials from memory — they are no longer needed.
+    # Wipe plaintext credentials from memory now that the login body has been sent.
+    # The Basic Auth header is not carried into the session — iBaseToken alone
+    # authenticates all subsequent calls, so the credential strings are not needed again.
     $username = $null
     $password = $null
-    [Array]::Clear($CredentialsBytes, 0, $CredentialsBytes.Length)
-    $CredentialsBytes = $null
-    $body             = $null
+    $body     = $null
 
     $SessionHeader = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-    $SessionHeader.Add("Authorization", "Basic $EncodedCredentials")
     $SessionHeader.Add("iBaseToken", $logonsession.data.iBaseToken)
 
     $connection = [OceanstorSession]::new($logonSession, $SessionHeader, $webSession, $Hostname)

--- a/POSH-Oceanstor/Public/Connect-deviceManager.ps1
+++ b/POSH-Oceanstor/Public/Connect-deviceManager.ps1
@@ -4,7 +4,9 @@ function Connect-deviceManager {
 		Connects to a Huawei OceanStor array by REST.
 
 	.DESCRIPTION
-		Starts a REST session to a Huawei OceanStor DeviceManager endpoint.
+		Starts a REST session to a Huawei OceanStor DeviceManager endpoint. When replacing the
+		global $deviceManager session (PassThru not specified), any existing global session is
+		closed first on a best-effort basis to avoid leaking a connection slot on the array.
 
 	.PARAMETER Hostname
 		Mandatory hostname or IP address of the Huawei OceanStor array.
@@ -107,6 +109,14 @@ function Connect-deviceManager {
         return $connection
     }
     else {
+        if ($global:deviceManager) {
+            try {
+                Disconnect-deviceManager -WebSession $global:deviceManager
+            }
+            catch {
+                Write-Warning "Failed to close the previous OceanStor session on '$($global:deviceManager.Hostname)': $($_.Exception.Message)"
+            }
+        }
         $global:deviceManager = $connection
     }
 }

--- a/POSH-Oceanstor/Public/Connect-deviceManager.ps1
+++ b/POSH-Oceanstor/Public/Connect-deviceManager.ps1
@@ -23,6 +23,9 @@ function Connect-deviceManager {
 		is a mandatory string when LoginPwd is provided. Is the login username to be used in the connection.
 	.PARAMETER LoginPWD
 		is a mandatory SecureString when LoginUser is provided.
+	.PARAMETER SkipCertificateCheck
+		When supplied, disables TLS certificate validation for the login request and all requests made with the returned session.
+		This should only be used for lab/test arrays or environments with self-signed certificates.
 	.INPUTS
 		System.String
 		System.Management.Automation.PSCredential
@@ -61,7 +64,8 @@ function Connect-deviceManager {
         [Parameter(Mandatory = $true, ParameterSetName = 'SecurePassword')]
         [String]$LoginUser,
         [Parameter(Mandatory = $true, ParameterSetName = 'SecurePassword')]
-        [securestring]$LoginPwd
+        [securestring]$LoginPwd,
+        [switch]$SkipCertificateCheck
     )
 
     switch ($PSCmdlet.ParameterSetName) {
@@ -86,7 +90,18 @@ function Connect-deviceManager {
 
     $webSession = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 
-    $logonsession = Invoke-RestMethod -Method Post -Uri "https://$($Hostname):8088/deviceManager/rest/xxxxx/sessions" -Body (ConvertTo-Json $body) -SkipCertificateCheck -SessionVariable WebSession
+    # Keep certificate validation enabled unless the caller explicitly opts out.
+    $invokeParams = @{
+        Method          = 'Post'
+        Uri             = "https://$($Hostname):8088/deviceManager/rest/xxxxx/sessions"
+        Body            = ConvertTo-Json $body
+        SessionVariable = 'WebSession'
+    }
+    if ($SkipCertificateCheck) {
+        $invokeParams.SkipCertificateCheck = $true
+    }
+
+    $logonsession = Invoke-RestMethod @invokeParams
 
     if ($logonsession.error.code -ne 0) {
         $SessionError = $logonsession.error
@@ -103,6 +118,7 @@ function Connect-deviceManager {
     $SessionHeader.Add("iBaseToken", $logonsession.data.iBaseToken)
 
     $connection = [OceanstorSession]::new($logonSession, $SessionHeader, $webSession, $Hostname)
+    $connection.SkipCertificateCheck = [bool]$SkipCertificateCheck
     $connection.Version = (Get-DMSystem -WebSession $connection).version
 
     if ($PassThru) {

--- a/POSH-Oceanstor/Public/Enable-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Enable-DMLunSnapshot.ps1
@@ -82,6 +82,7 @@ function Enable-DMLunSnapshot {
     }
 
     $snapshot = @(Get-DMLunSnapshot -WebSession $session | Where-Object Name -EQ $SnapShotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
 
     if ($PSCmdlet.ShouldProcess($SnapShotName, 'Activate LUN snapshot')) {
         $body = @{ SNAPSHOTLIST = @($snapshot.Id) }

--- a/POSH-Oceanstor/Public/Enable-DMSnapshotConsistencyGroup.ps1
+++ b/POSH-Oceanstor/Public/Enable-DMSnapshotConsistencyGroup.ps1
@@ -73,6 +73,7 @@ function Enable-DMSnapshotConsistencyGroup {
         $deviceManager
     }
     $group = @(Get-DMSnapshotConsistencyGroup -WebSession $session | Where-Object Name -EQ $Name)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $body = @{ ID = $group.Id }
     if ($group.'vStore ID') {
         $body.vstoreId = $group.'vStore ID'

--- a/POSH-Oceanstor/Public/Get-DMAlarm.ps1
+++ b/POSH-Oceanstor/Public/Get-DMAlarm.ps1
@@ -84,7 +84,7 @@ function Get-DMAlarm {
         }
     }
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "alarm/historyalarm?filter=alarmStatus:$statusAlarm" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "alarm/historyalarm?filter=alarmStatus:$statusAlarm" | Select-DMResponseData
     $alarms = New-Object System.Collections.ArrayList
 
     foreach ($talarm in $response) {

--- a/POSH-Oceanstor/Public/Get-DMController.ps1
+++ b/POSH-Oceanstor/Public/Get-DMController.ps1
@@ -54,7 +54,7 @@ function Get-DMController {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "controller" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "controller" | Select-DMResponseData
     $controllers = New-Object System.Collections.ArrayList
 
     foreach ($tcont in $response) {

--- a/POSH-Oceanstor/Public/Get-DMDiskbyLocation.ps1
+++ b/POSH-Oceanstor/Public/Get-DMDiskbyLocation.ps1
@@ -58,7 +58,7 @@ function Get-DMDiskbyLocation {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-DMResponseData
     $Storagedisks = New-Object System.Collections.ArrayList
 
     foreach ($tdisk in $response) {

--- a/POSH-Oceanstor/Public/Get-DMEnclosure.ps1
+++ b/POSH-Oceanstor/Public/Get-DMEnclosure.ps1
@@ -54,7 +54,7 @@ function Get-DMEnclosure {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "enclosure" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "enclosure" | Select-DMResponseData
     $enclosures = New-Object System.Collections.ArrayList
 
     foreach ($tenc in $response) {

--- a/POSH-Oceanstor/Public/Get-DMFiberChannelInitiator.ps1
+++ b/POSH-Oceanstor/Public/Get-DMFiberChannelInitiator.ps1
@@ -84,6 +84,7 @@ function Get-DMFiberChannelInitiator {
     }
     if ($HostName) {
         $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+        if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
         return @(Get-DMHostInitiator -WebSession $session -InitiatorType FibreChannel -HostId $hostObject.Id)
     }
     if ($FreeInitiators) {

--- a/POSH-Oceanstor/Public/Get-DMFileSystem.ps1
+++ b/POSH-Oceanstor/Public/Get-DMFileSystem.ps1
@@ -54,7 +54,7 @@ function Get-DMFileSystem {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "filesystem" | Select-Object -ExpandProperty data
+    $response = Invoke-DMPagedRequest -WebSession $session -Resource 'filesystem'
     $FileSystems = New-Object System.Collections.ArrayList
 
     foreach ($fs in $response) {

--- a/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
@@ -83,6 +83,7 @@ function Get-DMFileSystemSnapshot {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
+    if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
 
     if ($SnapshotName) {
         $snapshotId = "$($fileSystem.Id)@$SnapshotName"

--- a/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
@@ -83,24 +83,7 @@ function Get-DMFileSystemSnapshot {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
-    $resource = "fssnapshot?PARENTID=$($fileSystem.Id)"
-    $queryResult = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource $resource
-    $response = @()
-    if ($queryResult -is [string] -and -not [string]::IsNullOrWhiteSpace($queryResult)) {
-        $parsedResult = $queryResult | ConvertFrom-Json -AsHashtable -ErrorAction Stop
-        $response = @(
-            foreach ($snapshotData in @($parsedResult.data)) {
-                $normalizedData = [ordered]@{}
-                foreach ($key in $snapshotData.Keys) {
-                    $normalizedData[[string]$key] = $snapshotData[$key]
-                }
-                [pscustomobject]$normalizedData
-            }
-        )
-    }
-    elseif ($null -ne $queryResult -and $null -ne $queryResult.PSObject.Properties['data']) {
-        $response = @($queryResult.data)
-    }
+    $response = Invoke-DMPagedRequest -WebSession $session -Resource "fssnapshot?PARENTID=$($fileSystem.Id)"
     $defaultDisplaySet = 'Id', 'Name', 'Source File System Name', 'Health Status', 'Snapshot Type', 'Timestamp'
     $displayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet', [string[]]$defaultDisplaySet)
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)

--- a/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
@@ -83,7 +83,32 @@ function Get-DMFileSystemSnapshot {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
-    $response = Invoke-DMPagedRequest -WebSession $session -Resource "fssnapshot?PARENTID=$($fileSystem.Id)"
+
+    if ($SnapshotName) {
+        $snapshotId = "$($fileSystem.Id)@$SnapshotName"
+        $directResponse = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "fssnapshot/$snapshotId"
+        if ($directResponse -is [string]) {
+            $directResponse = $directResponse | ConvertFrom-Json
+        }
+        $directError = if ($null -ne $directResponse) { $directResponse.PSObject.Properties['error'] } else { $null }
+        $directData = if ($null -ne $directResponse) { $directResponse.PSObject.Properties['data'] } else { $null }
+        $response = if (($null -eq $directError -or $directError.Value.Code -eq 0) -and $null -ne $directData) {
+            @($directData.Value)
+        }
+        else {
+            @()
+        }
+    }
+    else {
+        $response = @()
+    }
+
+    if (@($response).Count -eq 0) {
+        $response = Invoke-DMPagedRequest -WebSession $session -Resource "fssnapshot?filter=PARENTID:$($fileSystem.Id)"
+        if (@($response).Count -eq 0) {
+            $response = Invoke-DMPagedRequest -WebSession $session -Resource "fssnapshot?PARENTID=$($fileSystem.Id)"
+        }
+    }
     $defaultDisplaySet = 'Id', 'Name', 'Source File System Name', 'Health Status', 'Snapshot Type', 'Timestamp'
     $displayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet', [string[]]$defaultDisplaySet)
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)

--- a/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Get-DMFileSystemSnapshot.ps1
@@ -87,11 +87,8 @@ function Get-DMFileSystemSnapshot {
     if ($SnapshotName) {
         $snapshotId = "$($fileSystem.Id)@$SnapshotName"
         $directResponse = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "fssnapshot/$snapshotId"
-        if ($directResponse -is [string]) {
-            $directResponse = $directResponse | ConvertFrom-Json
-        }
         $directError = if ($null -ne $directResponse) { $directResponse.PSObject.Properties['error'] } else { $null }
-        $directData = if ($null -ne $directResponse) { $directResponse.PSObject.Properties['data'] } else { $null }
+        $directData  = if ($null -ne $directResponse) { $directResponse.PSObject.Properties['data']  } else { $null }
         $response = if (($null -eq $directError -or $directError.Value.Code -eq 0) -and $null -ne $directData) {
             @($directData.Value)
         }
@@ -104,9 +101,11 @@ function Get-DMFileSystemSnapshot {
     }
 
     if (@($response).Count -eq 0) {
-        $response = Invoke-DMPagedRequest -WebSession $session -Resource "fssnapshot?filter=PARENTID:$($fileSystem.Id)"
+        $listResult = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "fssnapshot?filter=PARENTID:$($fileSystem.Id)"
+        $response = if ($null -ne $listResult -and $null -ne $listResult.data) { @($listResult.data) } else { @() }
         if (@($response).Count -eq 0) {
-            $response = Invoke-DMPagedRequest -WebSession $session -Resource "fssnapshot?PARENTID=$($fileSystem.Id)"
+            $listResult = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "fssnapshot?PARENTID=$($fileSystem.Id)"
+            $response = if ($null -ne $listResult -and $null -ne $listResult.data) { @($listResult.data) } else { @() }
         }
     }
     $defaultDisplaySet = 'Id', 'Name', 'Source File System Name', 'Health Status', 'Snapshot Type', 'Timestamp'

--- a/POSH-Oceanstor/Public/Get-DMHostLink.ps1
+++ b/POSH-Oceanstor/Public/Get-DMHostLink.ps1
@@ -77,7 +77,7 @@ function Get-DMHostLink {
         }
     }
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host_link?INITIATOR_TYPE=$LinkType&PARENTID=$HostId" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host_link?INITIATOR_TYPE=$LinkType&PARENTID=$HostId" | Select-DMResponseData
     $hostLinks = New-Object System.Collections.ArrayList
 
     foreach ($hlinks in $response) {

--- a/POSH-Oceanstor/Public/Get-DMInterfaceModule.ps1
+++ b/POSH-Oceanstor/Public/Get-DMInterfaceModule.ps1
@@ -54,7 +54,7 @@ function Get-DMInterfaceModule {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "intf_module" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "intf_module" | Select-DMResponseData
     $interfaceModules = New-Object System.Collections.ArrayList
 
     foreach ($imodule in $response) {

--- a/POSH-Oceanstor/Public/Get-DMIscsiInitiator.ps1
+++ b/POSH-Oceanstor/Public/Get-DMIscsiInitiator.ps1
@@ -84,6 +84,7 @@ function Get-DMIscsiInitiator {
     }
     if ($HostName) {
         $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+        if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
         return @(Get-DMHostInitiator -WebSession $session -InitiatorType ISCSI -HostId $hostObject.Id)
     }
     if ($FreeInitiators) {

--- a/POSH-Oceanstor/Public/Get-DMLif.ps1
+++ b/POSH-Oceanstor/Public/Get-DMLif.ps1
@@ -54,7 +54,7 @@ function Get-DMLif {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lif" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lif" | Select-DMResponseData
     $lifs = New-Object System.Collections.ArrayList
 
     foreach ($tlif in $response) {

--- a/POSH-Oceanstor/Public/Get-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Get-DMLunSnapshot.ps1
@@ -101,6 +101,7 @@ function Get-DMLunSnapshot {
     $resource = 'snapshot'
     if ($LunName) {
         $sourceLun = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $LunName)[0]
+        if ($null -eq $sourceLun) { throw "Could not resolve 'sourceLun' — the object may have been removed since parameter validation." }
         $resource = "snapshot?filter=SOURCELUNID:$($sourceLun.Id)"
     }
 

--- a/POSH-Oceanstor/Public/Get-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Get-DMLunSnapshot.ps1
@@ -104,8 +104,7 @@ function Get-DMLunSnapshot {
         $resource = "snapshot?filter=SOURCELUNID:$($sourceLun.Id)"
     }
 
-    $response = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource $resource |
-        Select-Object -ExpandProperty data
+    $response = Invoke-DMPagedRequest -WebSession $session -Resource $resource
     $snapshots = [System.Collections.ArrayList]::new()
 
     foreach ($snapshotData in @($response)) {

--- a/POSH-Oceanstor/Public/Get-DMLunsbyFilter.ps1
+++ b/POSH-Oceanstor/Public/Get-DMLunsbyFilter.ps1
@@ -72,7 +72,7 @@ function Get-DMLunsbyFilter {
 
     $apiField = $PropertyToApiField[$Filter]
     if ($apiField) {
-        $resource = "lun?filter=$($apiField):$Keyword"
+        $resource = "lun?filter=$($apiField):$([uri]::EscapeDataString($Keyword))"
     }
     else {
         $resource = "lun"

--- a/POSH-Oceanstor/Public/Get-DMLunsbyFilter.ps1
+++ b/POSH-Oceanstor/Public/Get-DMLunsbyFilter.ps1
@@ -87,7 +87,7 @@ function Get-DMLunsbyFilter {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-DMResponseData
     $StorageLuns = New-Object System.Collections.ArrayList
 
     $StorageVersion = $session.version.Substring(0, 2)

--- a/POSH-Oceanstor/Public/Get-DMMappingView.ps1
+++ b/POSH-Oceanstor/Public/Get-DMMappingView.ps1
@@ -150,6 +150,7 @@ function Get-DMMappingView {
     switch ($PSCmdlet.ParameterSetName) {
         'HostGroup' {
             $group = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $HostGroupName)[0]
+            if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
             if (-not $group) {
                 throw "Host group '$HostGroupName' was not found."
             }
@@ -157,6 +158,7 @@ function Get-DMMappingView {
         }
         'LunGroup' {
             $group = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+            if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
             if (-not $group) {
                 throw "LUN group '$LunGroupName' was not found."
             }
@@ -164,6 +166,7 @@ function Get-DMMappingView {
         }
         'PortGroup' {
             $group = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $PortGroupName)[0]
+            if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
             if (-not $group) {
                 throw "Port group '$PortGroupName' was not found."
             }

--- a/POSH-Oceanstor/Public/Get-DMNvmeInitiator.ps1
+++ b/POSH-Oceanstor/Public/Get-DMNvmeInitiator.ps1
@@ -96,6 +96,7 @@ function Get-DMNvmeInitiator {
 
     if ($HostName) {
         $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+        if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
         $parameters = @('ASSOCIATEOBJTYPE=21', "ASSOCIATEOBJID=$($hostObject.Id)")
         if ($VstoreId) {
             $parameters += "vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Get-DMPortBond.ps1
+++ b/POSH-Oceanstor/Public/Get-DMPortBond.ps1
@@ -54,7 +54,7 @@ function Get-DMPortBond {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "bond_port" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "bond_port" | Select-DMResponseData
     $bonds = New-Object System.Collections.ArrayList
 
     foreach ($tbond in $response) {

--- a/POSH-Oceanstor/Public/Get-DMPortETH.ps1
+++ b/POSH-Oceanstor/Public/Get-DMPortETH.ps1
@@ -54,7 +54,7 @@ function Get-DMPortETH {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "eth_port" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "eth_port" | Select-DMResponseData
     $ethPorts = New-Object System.Collections.ArrayList
 
     foreach ($peth in $response) {

--- a/POSH-Oceanstor/Public/Get-DMPortFc.ps1
+++ b/POSH-Oceanstor/Public/Get-DMPortFc.ps1
@@ -54,7 +54,7 @@ function Get-DMPortFc {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "fc_port" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "fc_port" | Select-DMResponseData
     $fcPorts = New-Object System.Collections.ArrayList
 
     foreach ($pfc in $response) {

--- a/POSH-Oceanstor/Public/Get-DMPortGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMPortGroup.ps1
@@ -58,7 +58,7 @@ function Get-DMPortGroup {
     }
 
     $response = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource $resource |
-        Select-Object -ExpandProperty data
+        Select-DMResponseData
     $defaultDisplaySet = 'Id', 'Name', 'Port Type', 'Port Count', 'Is Mapped', 'vStore Name'
     $displayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet', [string[]]$defaultDisplaySet)
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)

--- a/POSH-Oceanstor/Public/Get-DMPortSAS.ps1
+++ b/POSH-Oceanstor/Public/Get-DMPortSAS.ps1
@@ -54,7 +54,7 @@ function Get-DMPortSAS {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "sas_port" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "sas_port" | Select-DMResponseData
     $sasPorts = New-Object System.Collections.ArrayList
 
     foreach ($psas in $response) {

--- a/POSH-Oceanstor/Public/Get-DMProtectionGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMProtectionGroup.ps1
@@ -48,7 +48,7 @@ function Get-DMProtectionGroup {
         $deviceManager
     }
     $response = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource 'protectgroup' -ApiV2 |
-        Select-Object -ExpandProperty data
+        Select-DMResponseData
     $defaultDisplaySet = 'Id', 'Name', 'Lun Group Name', 'Lun Count', 'Snapshot Group Count', 'vStore Name'
     $displayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet', [string[]]$defaultDisplaySet)
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)

--- a/POSH-Oceanstor/Public/Get-DMShare.ps1
+++ b/POSH-Oceanstor/Public/Get-DMShare.ps1
@@ -70,7 +70,7 @@ function Get-DMShare {
         }
     }
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resourceQuery | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resourceQuery | Select-DMResponseData
     $shares = New-Object System.Collections.ArrayList
 
     foreach ($tshare in $response) {

--- a/POSH-Oceanstor/Public/Get-DMSnapshotConsistencyGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMSnapshotConsistencyGroup.ps1
@@ -48,7 +48,7 @@ function Get-DMSnapshotConsistencyGroup {
         $deviceManager
     }
     $response = Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource 'SNAPSHOT_CONSISTENCY_GROUP' |
-        Select-Object -ExpandProperty data
+        Select-DMResponseData
     $defaultDisplaySet = 'Id', 'Name', 'Protection Group Name', 'Running Status', 'Restore Speed', 'vStore Name'
     $displayPropertySet = New-Object System.Management.Automation.PSPropertySet('DefaultDisplayPropertySet', [string[]]$defaultDisplaySet)
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)

--- a/POSH-Oceanstor/Public/Get-DMSystem.ps1
+++ b/POSH-Oceanstor/Public/Get-DMSystem.ps1
@@ -45,7 +45,7 @@ function Get-DMSystem {
         $session = $deviceManager
     }
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "system/" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "system/" | Select-DMResponseData
     $response = $response -replace "[@{}]"
     [array]$systemArray = $response.Split(";")
 

--- a/POSH-Oceanstor/Public/Get-DMWorkLoadType.ps1
+++ b/POSH-Oceanstor/Public/Get-DMWorkLoadType.ps1
@@ -54,7 +54,7 @@ function Get-DMWorkLoadType {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "workload_type?isDetailInfo=true" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "workload_type?isDetailInfo=true" | Select-DMResponseData
     $workloads = New-Object System.Collections.ArrayList
 
     foreach ($tworkload in $response) {

--- a/POSH-Oceanstor/Public/Get-DMWorkLoadTypebyFilter.ps1
+++ b/POSH-Oceanstor/Public/Get-DMWorkLoadTypebyFilter.ps1
@@ -64,7 +64,7 @@ function Get-DMWorkLoadTypebyFilter {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "workload_type?isDetailInfo=true" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "workload_type?isDetailInfo=true" | Select-DMResponseData
     $workloads = New-Object System.Collections.ArrayList
 
     foreach ($tworkload in $response) {

--- a/POSH-Oceanstor/Public/Get-DMbbu.ps1
+++ b/POSH-Oceanstor/Public/Get-DMbbu.ps1
@@ -46,7 +46,7 @@ function Get-DMbbu {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "backup_power" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "backup_power" | Select-DMResponseData
     $bbus = New-Object System.Collections.ArrayList
 
     foreach ($bbu in $response) {

--- a/POSH-Oceanstor/Public/Get-DMcofferDisk.ps1
+++ b/POSH-Oceanstor/Public/Get-DMcofferDisk.ps1
@@ -54,7 +54,7 @@ function Get-DMcofferDisk {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-DMResponseData
     $Storagedisks = New-Object System.Collections.ArrayList
 
     foreach ($tdisk in $response) {

--- a/POSH-Oceanstor/Public/Get-DMdisk.ps1
+++ b/POSH-Oceanstor/Public/Get-DMdisk.ps1
@@ -54,7 +54,7 @@ function Get-DMdisk {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-DMResponseData
     $Storagedisks = New-Object System.Collections.ArrayList
 
     foreach ($tdisk in $response) {

--- a/POSH-Oceanstor/Public/Get-DMdiskbyPoolId.ps1
+++ b/POSH-Oceanstor/Public/Get-DMdiskbyPoolId.ps1
@@ -59,7 +59,7 @@ function Get-DMdiskbyPoolId {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-DMResponseData
     $Storagedisks = New-Object System.Collections.ArrayList
 
     foreach ($tdisk in $response) {

--- a/POSH-Oceanstor/Public/Get-DMdiskbyPoolName.ps1
+++ b/POSH-Oceanstor/Public/Get-DMdiskbyPoolName.ps1
@@ -59,7 +59,7 @@ function Get-DMdiskbyPoolName {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-DMResponseData
     $Storagedisks = New-Object System.Collections.ArrayList
 
     foreach ($tdisk in $response) {

--- a/POSH-Oceanstor/Public/Get-DMdnsServer.ps1
+++ b/POSH-Oceanstor/Public/Get-DMdnsServer.ps1
@@ -45,7 +45,7 @@ function Get-DMdnsServer {
     }
 
     $addressData = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "dns_server" |
-        Select-Object -ExpandProperty data |
+        Select-DMResponseData |
         Select-Object -ExpandProperty ADDRESS
 
     # OceanStor returns ADDRESS as a JSON-encoded array string, e.g. '["10.0.0.1","10.0.0.2"]'.

--- a/POSH-Oceanstor/Public/Get-DMdnsServer.ps1
+++ b/POSH-Oceanstor/Public/Get-DMdnsServer.ps1
@@ -44,18 +44,23 @@ function Get-DMdnsServer {
         $session = $deviceManager
     }
 
-    $response = $(Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "dns_server" | Select-Object -ExpandProperty data | Select-Object -ExpandProperty ADDRESS).ToString()
+    $addressData = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "dns_server" |
+        Select-Object -ExpandProperty data |
+        Select-Object -ExpandProperty ADDRESS
+
+    # OceanStor returns ADDRESS as a JSON-encoded array string, e.g. '["10.0.0.1","10.0.0.2"]'.
+    $addresses = if ($addressData -is [string]) {
+        @(ConvertFrom-Json -InputObject $addressData -ErrorAction Stop)
+    }
+    else {
+        @($addressData)
+    }
 
     $DnsServers = @{}
-
-    $splitResponse = $($response.Substring(0, $response.Length - 1)).substring(1).Split(",")
-
     $i = 1
-
-    foreach ($dnsS in $splitResponse) {
-        $dnstoAdd = $($dnsS.Substring(0, $dnsS.Length - 1)).substring(1).Split(",")
-        if ($dnstoAdd -ne "") {
-            $DnsServers.add("DNS Server $i", $dnstoAdd)
+    foreach ($address in $addresses) {
+        if ($address) {
+            $DnsServers.add("DNS Server $i", $address)
             $i = $i + 1
         }
     }

--- a/POSH-Oceanstor/Public/Get-DMfreeDisk.ps1
+++ b/POSH-Oceanstor/Public/Get-DMfreeDisk.ps1
@@ -54,7 +54,7 @@ function Get-DMfreeDisk {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "disk" | Select-DMResponseData
     $Storagedisks = New-Object System.Collections.ArrayList
 
     foreach ($tdisk in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhost.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhost.ps1
@@ -54,7 +54,12 @@ function Get-DMhost {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host" | Select-Object -ExpandProperty data
+    $queryResult = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host"
+    $errorProperty = if ($null -ne $queryResult) { $queryResult.PSObject.Properties['error'] } else { $null }
+    if ($null -ne $errorProperty -and $errorProperty.Value.Code -ne 0) {
+        throw "OceanStor API error $($errorProperty.Value.Code) retrieving hosts: $($errorProperty.Value.description)"
+    }
+    $response = $queryResult.data
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhost.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhost.ps1
@@ -35,7 +35,9 @@ function Get-DMhost {
     [Cmdletbinding()]
     param(
         [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True, Position = 0, Mandatory = $false)]
-        [pscustomobject]$WebSession
+        [pscustomobject]$WebSession,
+
+        [string]$VstoreId
     )
 
     if ($WebSession) {
@@ -54,7 +56,11 @@ function Get-DMhost {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $queryResult = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host"
+    $resource = 'host'
+    if ($VstoreId) {
+        $resource += "?vstoreId=$VstoreId"
+    }
+    $queryResult = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource
     $errorProperty = if ($null -ne $queryResult) { $queryResult.PSObject.Properties['error'] } else { $null }
     if ($null -ne $errorProperty -and $errorProperty.Value.Code -ne 0) {
         throw "OceanStor API error $($errorProperty.Value.Code) retrieving hosts: $($errorProperty.Value.description)"

--- a/POSH-Oceanstor/Public/Get-DMhostGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostGroup.ps1
@@ -60,7 +60,7 @@ function Get-DMhostGroup {
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"
     }
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-DMResponseData
     $hostgroups = New-Object System.Collections.ArrayList
 
     foreach ($hgroup in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostGroup.ps1
@@ -35,7 +35,9 @@ function Get-DMhostGroup {
     [Cmdletbinding()]
     param(
         [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True, Position = 0, Mandatory = $false)]
-        [pscustomobject]$WebSession
+        [pscustomobject]$WebSession,
+
+        [string]$VstoreId
     )
 
     if ($WebSession) {
@@ -54,7 +56,11 @@ function Get-DMhostGroup {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "hostgroup" | Select-Object -ExpandProperty data
+    $resource = 'hostgroup'
+    if ($VstoreId) {
+        $resource += "?vstoreId=$VstoreId"
+    }
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-Object -ExpandProperty data
     $hostgroups = New-Object System.Collections.ArrayList
 
     foreach ($hgroup in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostbyHostGroupId.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostbyHostGroupId.ps1
@@ -59,7 +59,7 @@ function Get-DMhostbyHostGroupId {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host" | Select-DMResponseData
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostbyHostGroupName.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostbyHostGroupName.ps1
@@ -59,7 +59,7 @@ function Get-DMhostbyHostGroupName {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host" | Select-DMResponseData
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostbyId.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostbyId.ps1
@@ -59,7 +59,7 @@ function Get-DMhostbyId {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=ID:$hostId" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=ID:$([uri]::EscapeDataString($hostId))" | Select-Object -ExpandProperty data
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostbyId.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostbyId.ps1
@@ -59,7 +59,7 @@ function Get-DMhostbyId {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=ID:$([uri]::EscapeDataString($hostId))" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=ID:$([uri]::EscapeDataString($hostId))" | Select-DMResponseData
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostbyName.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostbyName.ps1
@@ -59,7 +59,7 @@ function Get-DMhostbyName {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=NAME:$Name" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=NAME:$([uri]::EscapeDataString($Name))" | Select-Object -ExpandProperty data
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMhostbyName.ps1
+++ b/POSH-Oceanstor/Public/Get-DMhostbyName.ps1
@@ -59,7 +59,7 @@ function Get-DMhostbyName {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=NAME:$([uri]::EscapeDataString($Name))" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "host?filter=NAME:$([uri]::EscapeDataString($Name))" | Select-DMResponseData
     $hosts = New-Object System.Collections.ArrayList
 
     foreach ($thost in $response) {

--- a/POSH-Oceanstor/Public/Get-DMlun.ps1
+++ b/POSH-Oceanstor/Public/Get-DMlun.ps1
@@ -56,7 +56,7 @@ function Get-DMlun {
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lun" | Select-Object -ExpandProperty data
+    $response = Invoke-DMPagedRequest -WebSession $session -Resource 'lun'
     $StorageLuns = New-Object System.Collections.ArrayList
 
     $StorageVersion = $session.version.Substring(0, 2)

--- a/POSH-Oceanstor/Public/Get-DMlunByWWN.ps1
+++ b/POSH-Oceanstor/Public/Get-DMlunByWWN.ps1
@@ -62,7 +62,7 @@ function Get-DMlunByWWN {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lun?filter=WWN:$WWN" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lun?filter=WWN:$([uri]::EscapeDataString($WWN))" | Select-Object -ExpandProperty data
     $StorageLuns = New-Object System.Collections.ArrayList
 
     $StorageVersion = $session.version.Substring(0, 2)

--- a/POSH-Oceanstor/Public/Get-DMlunByWWN.ps1
+++ b/POSH-Oceanstor/Public/Get-DMlunByWWN.ps1
@@ -62,7 +62,7 @@ function Get-DMlunByWWN {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lun?filter=WWN:$([uri]::EscapeDataString($WWN))" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lun?filter=WWN:$([uri]::EscapeDataString($WWN))" | Select-DMResponseData
     $StorageLuns = New-Object System.Collections.ArrayList
 
     $StorageVersion = $session.version.Substring(0, 2)

--- a/POSH-Oceanstor/Public/Get-DMlunGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMlunGroup.ps1
@@ -65,7 +65,7 @@ function Get-DMlunGroup {
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"
     }
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-DMResponseData
     $lunGroups = New-Object System.Collections.ArrayList
 
     foreach ($lgroup in $response) {

--- a/POSH-Oceanstor/Public/Get-DMlunGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMlunGroup.ps1
@@ -40,7 +40,9 @@ function Get-DMlunGroup {
     [Cmdletbinding()]
     param(
         [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True, Position = 0, Mandatory = $false)]
-        [pscustomobject]$WebSession
+        [pscustomobject]$WebSession,
+
+        [string]$VstoreId
     )
 
     if ($WebSession) {
@@ -59,7 +61,11 @@ function Get-DMlunGroup {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "lungroup" | Select-Object -ExpandProperty data
+    $resource = 'lungroup'
+    if ($VstoreId) {
+        $resource += "?vstoreId=$VstoreId"
+    }
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource $resource | Select-Object -ExpandProperty data
     $lunGroups = New-Object System.Collections.ArrayList
 
     foreach ($lgroup in $response) {

--- a/POSH-Oceanstor/Public/Get-DMlunbyLunGroup.ps1
+++ b/POSH-Oceanstor/Public/Get-DMlunbyLunGroup.ps1
@@ -77,7 +77,10 @@ function Get-DMlunbyLunGroup {
             $associatedLunIds = @(ConvertFrom-Json -InputObject $associatedLunIdList -ErrorAction Stop)
         }
         catch {
-            $associatedLunIds = @($associatedLunIdList -split ',')
+            # Strip surrounding JSON-array brackets before splitting so that both
+            # "[1,2,3]" and "1,2,3" produce the same clean id list.
+            $stripped = $associatedLunIdList.Trim().TrimStart('[').TrimEnd(']')
+            $associatedLunIds = @($stripped -split ',')
         }
     }
     else {

--- a/POSH-Oceanstor/Public/Get-DMnfsFileClient.ps1
+++ b/POSH-Oceanstor/Public/Get-DMnfsFileClient.ps1
@@ -54,7 +54,7 @@ function Get-DMnfsFileClient {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "NFS_SHARE_AUTH_CLIENT" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "NFS_SHARE_AUTH_CLIENT" | Select-DMResponseData
     $exports = New-Object System.Collections.ArrayList
 
     foreach ($fs in $response) {

--- a/POSH-Oceanstor/Public/Get-DMstoragePool.ps1
+++ b/POSH-Oceanstor/Public/Get-DMstoragePool.ps1
@@ -54,7 +54,7 @@ function Get-DMstoragePool {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "storagepool" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "storagepool" | Select-DMResponseData
     $storagePools = New-Object System.Collections.ArrayList
 
     foreach ($spool in $response) {

--- a/POSH-Oceanstor/Public/Get-DMvLan.ps1
+++ b/POSH-Oceanstor/Public/Get-DMvLan.ps1
@@ -54,7 +54,7 @@ function Get-DMvLan {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "vlan" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "vlan" | Select-DMResponseData
     $vlans = New-Object System.Collections.ArrayList
 
     foreach ($tvlan in $response) {

--- a/POSH-Oceanstor/Public/Get-DMvStore.ps1
+++ b/POSH-Oceanstor/Public/Get-DMvStore.ps1
@@ -54,7 +54,7 @@ function Get-DMvStore {
 
     $standardMembers = [System.Management.Automation.PSMemberInfo[]]@($displayPropertySet)
 
-    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "vstore" | Select-Object -ExpandProperty data
+    $response = Invoke-DeviceManager -WebSession $session -Method "GET" -Resource "vstore" | Select-DMResponseData
     $vStores = New-Object System.Collections.ArrayList
 
     foreach ($tvstore in $response) {

--- a/POSH-Oceanstor/Public/New-DMCifsShare.ps1
+++ b/POSH-Oceanstor/Public/New-DMCifsShare.ps1
@@ -165,6 +165,7 @@ function New-DMCifsShare {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
+    if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
     $subTypeValue = @{ Normal = 0; HomeDir = 1; All = 2 }[$SubType]
     $offlineFileModeValue = @{ None = 0; Manual = 1; Documents = 2; Programs = 3 }[$OfflineFileMode]
     $body = @{

--- a/POSH-Oceanstor/Public/New-DMFiberChannelInitiator.ps1
+++ b/POSH-Oceanstor/Public/New-DMFiberChannelInitiator.ps1
@@ -133,6 +133,7 @@ function New-DMFiberChannelInitiator {
     }
     if ($HostName) {
         $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+        if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
         $body.PARENTTYPE = 21
         $body.PARENTID = $hostObject.Id
     }

--- a/POSH-Oceanstor/Public/New-DMFileSystem.ps1
+++ b/POSH-Oceanstor/Public/New-DMFileSystem.ps1
@@ -100,9 +100,9 @@ function New-DMFileSystem {
     param(
         [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True, Position = 0, Mandatory = $false)]
         [pscustomobject]$WebSession,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $true)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 1, Mandatory = $true)]
         [string]$FileSystemName,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $true)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 2, Mandatory = $true)]
         [ValidateScript({
                 $session = if ($WebSession) {
                     $WebSession
@@ -127,42 +127,42 @@ function New-DMFileSystem {
                 (Get-DMstoragePool -WebSession $session).Id | Sort-Object -Unique | Where-Object { $_ -like "$wordToComplete*" }
             })]
         [Int16]$StoragePoolID,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [string]$description,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$Worm = $false,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         [object]$capacity,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [Int32]$snapShotReserve = 20,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [string]$autoDeleteSnap = $false,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [int64]$AlarmThresold = 90,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [ValidateSet("database", "VM", "user-defined")]
         [string]$usage = "user-defined",
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$checkSumEnable = $true,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$accessTime = $false,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [ValidateSet("Hourly", "Daily", "disabled")]
         [string]$accessTimeUpdateMode = "disabled",
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$readOnly = $false,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [ValidateSet("low", "medium", "high")]
         [string]$FileSystemIOpriority = "low",
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$Compression = $false,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [ValidateSet("rapid", "deep")]
         [string]$CompressionAlgorithm = "rapid",
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$Dedupe = $false,
-        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Position = 0, Mandatory = $false)]
+        [Parameter(ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $false, Mandatory = $false)]
         [bool]$Autogrow = $false
     )
 

--- a/POSH-Oceanstor/Public/New-DMFileSystem.ps1
+++ b/POSH-Oceanstor/Public/New-DMFileSystem.ps1
@@ -220,52 +220,7 @@ function New-DMFileSystem {
 
     $capacityInBlocks = $null
     if ($PSBoundParameters.ContainsKey('capacity')) {
-        # OceanStor expects file-system capacity as a count of 512-byte blocks.
-        # Unitless integers retain the command's historical gigabyte behavior.
-        $capacityText = ([string]$capacity).Trim()
-        if ($capacityText -match '^(?<Value>(?:\d+(?:[.,]\d+)?|[.,]\d+))\s*(?<Unit>MB|GB|TB)$') {
-            $size = [decimal]0
-            $normalizedValue = $Matches.Value.Replace(',', '.')
-            $parsed = [decimal]::TryParse(
-                $normalizedValue,
-                [Globalization.NumberStyles]::AllowDecimalPoint,
-                [Globalization.CultureInfo]::InvariantCulture,
-                [ref]$size
-            )
-            if (-not $parsed -or $size -le 0) {
-                throw "Capacity must be greater than zero. Received '$capacityText'."
-            }
-
-            $blocksPerUnit = switch ($Matches.Unit.ToUpperInvariant()) {
-                'MB' { [decimal]2048 }
-                'GB' { [decimal]2097152 }
-                'TB' { [decimal]2147483648 }
-            }
-            $blockCount = $size * $blocksPerUnit
-        }
-        else {
-            $sizeInGB = [long]0
-            if (-not [long]::TryParse(
-                    $capacityText,
-                    [Globalization.NumberStyles]::Integer,
-                    [Globalization.CultureInfo]::InvariantCulture,
-                    [ref]$sizeInGB
-                )) {
-                throw "Invalid capacity '$capacityText'. Use a positive value followed by MB, GB, or TB (for example, 10GB)."
-            }
-            if ($sizeInGB -le 0) {
-                throw "Capacity must be greater than zero. Received '$capacityText'."
-            }
-            $blockCount = [decimal]$sizeInGB * [decimal]2097152
-        }
-
-        if ($blockCount -gt [long]::MaxValue) {
-            throw "Capacity '$capacityText' exceeds the supported maximum."
-        }
-        if ([decimal]::Truncate($blockCount) -ne $blockCount) {
-            throw "Capacity '$capacityText' does not resolve to a whole number of 512-byte blocks."
-        }
-        $capacityInBlocks = [long]$blockCount
+        $capacityInBlocks = ConvertTo-DMCapacityBlock -Capacity $capacity -UnitlessUnit GB
     }
 
     $body = @{

--- a/POSH-Oceanstor/Public/New-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/New-DMFileSystemSnapshot.ps1
@@ -99,6 +99,7 @@ function New-DMFileSystemSnapshot {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
+    if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
     $body = @{
         NAME       = if ($SnapshotName) {
             $SnapshotName

--- a/POSH-Oceanstor/Public/New-DMIscsiInitiator.ps1
+++ b/POSH-Oceanstor/Public/New-DMIscsiInitiator.ps1
@@ -150,6 +150,7 @@ function New-DMIscsiInitiator {
     }
     if ($HostName) {
         $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+        if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
         $body.PARENTTYPE = 21
         $body.PARENTID = $hostObject.Id
     }

--- a/POSH-Oceanstor/Public/New-DMLun.ps1
+++ b/POSH-Oceanstor/Public/New-DMLun.ps1
@@ -181,50 +181,7 @@ function New-DMLun {
         $StoragePoolID = $PSBoundParameters['StoragePoolID']
     }
 
-    # OceanStor expects LUN capacity as a count of 512-byte blocks. Accept a
-    # human-readable binary size while retaining legacy raw-block input.
-    $capacityText = ([string]$capacity).Trim()
-    $capacityInBlocks = [long]0
-    if ($capacityText -match '^(?<Value>(?:\d+(?:[.,]\d+)?|[.,]\d+))\s*(?<Unit>MB|GB|TB)$') {
-        $size = [decimal]0
-        $normalizedValue = $Matches.Value.Replace(',', '.')
-        $parsed = [decimal]::TryParse(
-            $normalizedValue,
-            [Globalization.NumberStyles]::AllowDecimalPoint,
-            [Globalization.CultureInfo]::InvariantCulture,
-            [ref]$size
-        )
-        if (-not $parsed -or $size -le 0) {
-            throw "Capacity must be greater than zero. Received '$capacityText'."
-        }
-
-        $blocksPerUnit = switch ($Matches.Unit.ToUpperInvariant()) {
-            'MB' { [decimal]2048 }
-            'GB' { [decimal]2097152 }
-            'TB' { [decimal]2147483648 }
-        }
-        $blockCount = $size * $blocksPerUnit
-        if ($blockCount -gt [long]::MaxValue) {
-            throw "Capacity '$capacityText' exceeds the supported maximum."
-        }
-        if ([decimal]::Truncate($blockCount) -ne $blockCount) {
-            throw "Capacity '$capacityText' does not resolve to a whole number of 512-byte blocks."
-        }
-        $capacityInBlocks = [long]$blockCount
-    }
-    elseif ([long]::TryParse(
-            $capacityText,
-            [Globalization.NumberStyles]::Integer,
-            [Globalization.CultureInfo]::InvariantCulture,
-            [ref]$capacityInBlocks
-        )) {
-        if ($capacityInBlocks -le 0) {
-            throw "Capacity must be greater than zero. Received '$capacityText'."
-        }
-    }
-    else {
-        throw "Invalid capacity '$capacityText'. Use a positive value followed by MB, GB, or TB (for example, 10GB)."
-    }
+    $capacityInBlocks = ConvertTo-DMCapacityBlock -Capacity $capacity -UnitlessUnit Blocks
 
     # Convert allocation type to Huawei API value
     switch ($allocType) {

--- a/POSH-Oceanstor/Public/New-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/New-DMLunSnapshot.ps1
@@ -105,6 +105,7 @@ function New-DMLunSnapshot {
     }
 
     $sourceLun = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $SourceLunName)[0]
+    if ($null -eq $sourceLun) { throw "Could not resolve 'sourceLun' — the object may have been removed since parameter validation." }
 
     $body = @{
         TYPE       = 27

--- a/POSH-Oceanstor/Public/New-DMLunSnapshotCopy.ps1
+++ b/POSH-Oceanstor/Public/New-DMLunSnapshotCopy.ps1
@@ -103,6 +103,7 @@ function New-DMLunSnapshotCopy {
     }
 
     $sourceSnapshot = @(Get-DMLunSnapshot -WebSession $session | Where-Object Name -EQ $SourceSnapShotName)[0]
+    if ($null -eq $sourceSnapshot) { throw "Could not resolve 'sourceSnapshot' — the object may have been removed since parameter validation." }
 
     $resolvedCopyName = $SnapshotCopyName
     if (-not $resolvedCopyName) {

--- a/POSH-Oceanstor/Public/New-DMProtectionGroup.ps1
+++ b/POSH-Oceanstor/Public/New-DMProtectionGroup.ps1
@@ -125,6 +125,7 @@ function New-DMProtectionGroup {
         $deviceManager
     }
     $lunGroup = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+    if ($null -eq $lunGroup) { throw "Could not resolve 'lunGroup' — the object may have been removed since parameter validation." }
     $body = @{
         protectGroupName = $Name
         lunGroupId       = $lunGroup.Id
@@ -132,6 +133,7 @@ function New-DMProtectionGroup {
 
     if ($Vstore) {
         $vstoreObject = @(Get-DMvStore -WebSession $session | Where-Object Name -EQ $Vstore)[0]
+        if ($null -eq $vstoreObject) { throw "Could not resolve 'vstoreObject' — the object may have been removed since parameter validation." }
         $body.vstoreId = $vstoreObject.Id
     }
     if ($Description) {

--- a/POSH-Oceanstor/Public/New-DMSnapshotConsistencyGroup.ps1
+++ b/POSH-Oceanstor/Public/New-DMSnapshotConsistencyGroup.ps1
@@ -92,6 +92,7 @@ function New-DMSnapshotConsistencyGroup {
         $deviceManager
     }
     $protectionGroup = @(Get-DMProtectionGroup -WebSession $session | Where-Object Name -EQ $ProtectionGroupName)[0]
+    if ($null -eq $protectionGroup) { throw "Could not resolve 'protectionGroup' — the object may have been removed since parameter validation." }
     $body = @{ NAME = $Name; PARENTID = $protectionGroup.Id }
     if ($Description) {
         $body.DESCRIPTION = $Description

--- a/POSH-Oceanstor/Public/New-DMSnapshotConsistencyGroupCopy.ps1
+++ b/POSH-Oceanstor/Public/New-DMSnapshotConsistencyGroupCopy.ps1
@@ -92,6 +92,7 @@ function New-DMSnapshotConsistencyGroupCopy {
         $deviceManager
     }
     $source = @(Get-DMSnapshotConsistencyGroup -WebSession $session | Where-Object Name -EQ $SourceName)[0]
+    if ($null -eq $source) { throw "Could not resolve 'source' — the object may have been removed since parameter validation." }
     $body = @{
         COPYSOURCEID = $source.Id
         NAME         = if ($Name) {

--- a/POSH-Oceanstor/Public/Remove-DMCifsShare.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMCifsShare.ps1
@@ -79,6 +79,7 @@ function Remove-DMCifsShare {
         $deviceManager
     }
     $share = @(Get-DMShare -WebSession $session -ShareType CIFS | Where-Object Name -EQ $ShareName)[0]
+    if ($null -eq $share) { throw "Could not resolve 'share' — the object may have been removed since parameter validation." }
     $resource = "CIFSSHARE/$($share.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMDTree.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMDTree.ps1
@@ -80,6 +80,7 @@ function Remove-DMDTree {
                     $deviceManager
                 }
                 $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
+                if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
                 $dtrees = @((Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "QUOTATREE?PARENTID=$($fileSystem.Id)").data)
                 $matchingItems = @($dtrees | Where-Object NAME -EQ $_)
                 if ($matchingItems.Count -eq 1) {
@@ -102,6 +103,7 @@ function Remove-DMDTree {
                     $deviceManager
                 }
                 $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $fakeBoundParameters.FileSystemName)[0]
+                if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
                 if (-not $fileSystem) {
                     return
                 }
@@ -120,8 +122,10 @@ function Remove-DMDTree {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
+    if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
     $dtrees = @((Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "QUOTATREE?PARENTID=$($fileSystem.Id)").data)
     $dtree = @($dtrees | Where-Object NAME -EQ $DTreeName)[0]
+    if ($null -eq $dtree) { throw "Could not resolve 'dtree' — the object may have been removed since parameter validation." }
     $resource = "QUOTATREE/$($dtree.ID)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMDTree.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMDTree.ps1
@@ -80,7 +80,6 @@ function Remove-DMDTree {
                     $deviceManager
                 }
                 $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
-                if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
                 $dtrees = @((Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource "QUOTATREE?PARENTID=$($fileSystem.Id)").data)
                 $matchingItems = @($dtrees | Where-Object NAME -EQ $_)
                 if ($matchingItems.Count -eq 1) {

--- a/POSH-Oceanstor/Public/Remove-DMFiberChannelInitiator.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMFiberChannelInitiator.ps1
@@ -74,9 +74,9 @@ function Remove-DMFiberChannelInitiator {
     else {
         $deviceManager
     }
-    $resource = "fc_initiator/$WWN"
+    $resource = "fc_initiator/$([uri]::EscapeDataString($WWN))"
     if ($VstoreId) {
-        $resource += "?vstoreId=$VstoreId"
+        $resource += "?vstoreId=$([uri]::EscapeDataString($VstoreId))"
     }
     if ($PSCmdlet.ShouldProcess($WWN, 'Remove free Fibre Channel initiator')) {
         return (Invoke-DeviceManager -WebSession $session -Method 'DELETE' -Resource $resource).error

--- a/POSH-Oceanstor/Public/Remove-DMFiberChannelInitiatorFromHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMFiberChannelInitiatorFromHost.ps1
@@ -83,6 +83,7 @@ function Remove-DMFiberChannelInitiatorFromHost {
                 }
                 $selectedHostName = [string]$HostName
                 $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $selectedHostName)[0]
+                if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
                 $initiators = @(Get-DMHostInitiator -WebSession $session -InitiatorType FibreChannel -HostId $hostObject.Id)
                 if ($initiators.Id -contains $candidate) {
                     return $true

--- a/POSH-Oceanstor/Public/Remove-DMFiberChannelInitiatorFromHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMFiberChannelInitiatorFromHost.ps1
@@ -83,7 +83,6 @@ function Remove-DMFiberChannelInitiatorFromHost {
                 }
                 $selectedHostName = [string]$HostName
                 $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $selectedHostName)[0]
-                if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
                 $initiators = @(Get-DMHostInitiator -WebSession $session -InitiatorType FibreChannel -HostId $hostObject.Id)
                 if ($initiators.Id -contains $candidate) {
                     return $true

--- a/POSH-Oceanstor/Public/Remove-DMFileSystem.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMFileSystem.ps1
@@ -93,6 +93,7 @@ function Remove-DMFileSystem {
         $deviceManager
     }
     $fileSystem = @(Get-DMFileSystem -WebSession $session | Where-Object Name -EQ $FileSystemName)[0]
+    if ($null -eq $fileSystem) { throw "Could not resolve 'fileSystem' — the object may have been removed since parameter validation." }
     $parameters = @()
     if ($Force) {
         $parameters += 'forceDeleteFs=true'

--- a/POSH-Oceanstor/Public/Remove-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMFileSystemSnapshot.ps1
@@ -76,7 +76,7 @@ function Remove-DMFileSystemSnapshot {
                 else {
                     $deviceManager
                 }
-                $snapshots = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName)
+                $snapshots = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName -SnapshotName $_)
                 $matchingItems = @($snapshots | Where-Object Name -EQ $_)
                 if ($matchingItems.Count -eq 1) {
                     return $true
@@ -109,7 +109,7 @@ function Remove-DMFileSystemSnapshot {
     else {
         $deviceManager
     }
-    $snapshot = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName | Where-Object Name -EQ $SnapshotName)[0]
+    $snapshot = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName -SnapshotName $SnapshotName)[0]
 
     if ($PSCmdlet.ShouldProcess("$FileSystemName/$SnapshotName", 'Remove file-system snapshot')) {
         $response = Invoke-DeviceManager -WebSession $session -Method 'DELETE' -Resource "fssnapshot/$($snapshot.Id)"

--- a/POSH-Oceanstor/Public/Remove-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMFileSystemSnapshot.ps1
@@ -110,6 +110,7 @@ function Remove-DMFileSystemSnapshot {
         $deviceManager
     }
     $snapshot = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName -SnapshotName $SnapshotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
 
     if ($PSCmdlet.ShouldProcess("$FileSystemName/$SnapshotName", 'Remove file-system snapshot')) {
         $response = Invoke-DeviceManager -WebSession $session -Method 'DELETE' -Resource "fssnapshot/$($snapshot.Id)"

--- a/POSH-Oceanstor/Public/Remove-DMHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMHost.ps1
@@ -78,6 +78,7 @@ function Remove-DMHost {
         $deviceManager
     }
     $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+    if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
     $resource = "host/$($hostObject.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMHostFromHostGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMHostFromHostGroup.ps1
@@ -113,7 +113,9 @@ function Remove-DMHostFromHostGroup {
         $deviceManager
     }
     $hostObject = @($script:_dmRemoveHostHosts | Where-Object Name -EQ $HostName)[0]
+    if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
     $group = @($script:_dmRemoveHostGroups | Where-Object Name -EQ $HostGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $members = @(Get-DMhostbyHostGroupId -WebSession $session -HostGroupId $group.Id)
     if ($members.Id -notcontains $hostObject.Id) {
         throw "Host '$HostName' is not a member of host group '$HostGroupName'."

--- a/POSH-Oceanstor/Public/Remove-DMHostFromHostGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMHostFromHostGroup.ps1
@@ -50,15 +50,15 @@ function Remove-DMHostFromHostGroup {
                 else {
                     $deviceManager
                 }
-                $hosts = @(Get-DMhost -WebSession $session)
-                $matchingItems = @($hosts | Where-Object Name -EQ $candidate)
+                $script:_dmRemoveHostHosts = @(Get-DMhost -WebSession $session)
+                $matchingItems = @($script:_dmRemoveHostHosts | Where-Object Name -EQ $candidate)
                 if ($matchingItems.Count -eq 1) {
                     return $true
                 }
                 if ($matchingItems.Count -gt 1) {
                     throw "HostName is ambiguous because more than one host is named '$candidate'."
                 }
-                throw "Invalid HostName. Valid values are: $($hosts.Name -join ', ')"
+                throw "Invalid HostName. Valid values are: $($script:_dmRemoveHostHosts.Name -join ', ')"
             })]
         [ArgumentCompleter({
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
@@ -81,15 +81,15 @@ function Remove-DMHostFromHostGroup {
                 else {
                     $deviceManager
                 }
-                $groups = @(Get-DMhostGroup -WebSession $session)
-                $matchingItems = @($groups | Where-Object Name -EQ $candidate)
+                $script:_dmRemoveHostGroups = @(Get-DMhostGroup -WebSession $session)
+                $matchingItems = @($script:_dmRemoveHostGroups | Where-Object Name -EQ $candidate)
                 if ($matchingItems.Count -eq 1) {
                     return $true
                 }
                 if ($matchingItems.Count -gt 1) {
                     throw "HostGroupName is ambiguous because more than one host group is named '$candidate'."
                 }
-                throw "Invalid HostGroupName. Valid values are: $($groups.Name -join ', ')"
+                throw "Invalid HostGroupName. Valid values are: $($script:_dmRemoveHostGroups.Name -join ', ')"
             })]
         [ArgumentCompleter({
                 param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
@@ -112,8 +112,8 @@ function Remove-DMHostFromHostGroup {
     else {
         $deviceManager
     }
-    $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
-    $group = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $HostGroupName)[0]
+    $hostObject = @($script:_dmRemoveHostHosts | Where-Object Name -EQ $HostName)[0]
+    $group = @($script:_dmRemoveHostGroups | Where-Object Name -EQ $HostGroupName)[0]
     $members = @(Get-DMhostbyHostGroupId -WebSession $session -HostGroupId $group.Id)
     if ($members.Id -notcontains $hostObject.Id) {
         throw "Host '$HostName' is not a member of host group '$HostGroupName'."

--- a/POSH-Oceanstor/Public/Remove-DMHostGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMHostGroup.ps1
@@ -78,6 +78,7 @@ function Remove-DMHostGroup {
         $deviceManager
     }
     $group = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $HostGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $resource = "hostgroup/$($group.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMHostGroupFromMappingView.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMHostGroupFromMappingView.ps1
@@ -111,10 +111,12 @@ function Remove-DMHostGroupFromMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     if (-not $view) {
         throw "Mapping view '$MappingViewName' was not found."
     }
     $group = @(Get-DMhostGroup -WebSession $session | Where-Object Name -EQ $HostGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     if (-not $group) {
         throw "Host group '$HostGroupName' was not found."
     }

--- a/POSH-Oceanstor/Public/Remove-DMIscsiInitiatorFromHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMIscsiInitiatorFromHost.ps1
@@ -83,7 +83,6 @@ function Remove-DMIscsiInitiatorFromHost {
                 }
                 $selectedHostName = [string]$HostName
                 $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $selectedHostName)[0]
-                if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
                 $initiators = @(Get-DMHostInitiator -WebSession $session -InitiatorType ISCSI -HostId $hostObject.Id)
                 if ($initiators.Id -contains $candidate) {
                     return $true

--- a/POSH-Oceanstor/Public/Remove-DMIscsiInitiatorFromHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMIscsiInitiatorFromHost.ps1
@@ -83,6 +83,7 @@ function Remove-DMIscsiInitiatorFromHost {
                 }
                 $selectedHostName = [string]$HostName
                 $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $selectedHostName)[0]
+                if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
                 $initiators = @(Get-DMHostInitiator -WebSession $session -InitiatorType ISCSI -HostId $hostObject.Id)
                 if ($initiators.Id -contains $candidate) {
                     return $true

--- a/POSH-Oceanstor/Public/Remove-DMLun.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMLun.ps1
@@ -88,6 +88,11 @@ function Remove-DMLun {
         $deviceManager
     }
     $lun = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $LunName)[0]
+
+    if ($lun.'is Mapped' -eq 'mapped') {
+        throw "Cannot remove LUN '$LunName': it is currently mapped to a host. Remove the mapping view first."
+    }
+
     $parameters = @()
     if ($ImmediateDelete) {
         $parameters += 'isDelayDelete=false'

--- a/POSH-Oceanstor/Public/Remove-DMLun.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMLun.ps1
@@ -88,6 +88,7 @@ function Remove-DMLun {
         $deviceManager
     }
     $lun = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $LunName)[0]
+    if ($null -eq $lun) { throw "Could not resolve 'lun' — the object may have been removed since parameter validation." }
 
     if ($lun.'is Mapped' -eq 'mapped') {
         throw "Cannot remove LUN '$LunName': it is currently mapped to a host. Remove the mapping view first."

--- a/POSH-Oceanstor/Public/Remove-DMLunFromLunGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMLunFromLunGroup.ps1
@@ -113,7 +113,9 @@ function Remove-DMLunFromLunGroup {
         $deviceManager
     }
     $lun = @(Get-DMlun -WebSession $session | Where-Object Name -EQ $LunName)[0]
+    if ($null -eq $lun) { throw "Could not resolve 'lun' — the object may have been removed since parameter validation." }
     $group = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $members = @(Get-DMlunbyLunGroup -WebSession $session -LunGroup $group)
     if ($members.Id -notcontains $lun.Id) {
         throw "LUN '$LunName' is not a member of LUN group '$LunGroupName'."

--- a/POSH-Oceanstor/Public/Remove-DMLunGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMLunGroup.ps1
@@ -78,6 +78,7 @@ function Remove-DMLunGroup {
         $deviceManager
     }
     $group = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $resource = "lungroup/$($group.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMLunGroupFromMappingView.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMLunGroupFromMappingView.ps1
@@ -111,10 +111,12 @@ function Remove-DMLunGroupFromMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     if (-not $view) {
         throw "Mapping view '$MappingViewName' was not found."
     }
     $group = @(Get-DMlunGroup -WebSession $session | Where-Object Name -EQ $LunGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     if (-not $group) {
         throw "LUN group '$LunGroupName' was not found."
     }

--- a/POSH-Oceanstor/Public/Remove-DMLunSnapShot.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMLunSnapShot.ps1
@@ -87,6 +87,7 @@ function Remove-DMLunSnapShot {
     }
 
     $snapshot = @(Get-DMLunSnapshot -WebSession $session | Where-Object Name -EQ $SnapShotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
 
     if ($PSCmdlet.ShouldProcess($SnapShotName, 'Remove LUN snapshot')) {
         $response = Invoke-DeviceManager -WebSession $session -Method 'DELETE' -Resource "snapshot/$($snapshot.Id)"

--- a/POSH-Oceanstor/Public/Remove-DMMappingView.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMMappingView.ps1
@@ -75,6 +75,7 @@ function Remove-DMMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     $resource = "mappingview/$($view.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMNfsClient.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMNfsClient.ps1
@@ -78,6 +78,7 @@ function Remove-DMNfsClient {
         $deviceManager
     }
     $client = @(Get-DMnfsFileClient -WebSession $session | Where-Object Name -EQ $ClientName)[0]
+    if ($null -eq $client) { throw "Could not resolve 'client' — the object may have been removed since parameter validation." }
     $resource = "NFS_SHARE_AUTH_CLIENT/$($client.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMNfsShare.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMNfsShare.ps1
@@ -89,6 +89,7 @@ function Remove-DMNfsShare {
         $deviceManager
     }
     $share = @(Get-DMShare -WebSession $session -ShareType NFS | Where-Object 'Share Path' -EQ $SharePath)[0]
+    if ($null -eq $share) { throw "Could not resolve 'share' — the object may have been removed since parameter validation." }
     $parameters = @()
     if ($PrivateShare) {
         $parameters += 'sharePrivate=1'

--- a/POSH-Oceanstor/Public/Remove-DMNvmeInitiatorFromHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMNvmeInitiatorFromHost.ps1
@@ -83,6 +83,7 @@ function Remove-DMNvmeInitiatorFromHost {
                 }
                 $selectedHostName = [string]$HostName
                 $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $selectedHostName)[0]
+                if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
                 $resource = "NVMe_over_RoCE_initiator/associate?ASSOCIATEOBJTYPE=21&ASSOCIATEOBJID=$($hostObject.Id)"
                 $initiators = @((Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource $resource).data)
                 if ($initiators.ID -contains $candidate) {
@@ -115,6 +116,7 @@ function Remove-DMNvmeInitiatorFromHost {
         $deviceManager
     }
     $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $HostName)[0]
+    if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
     $body = @{
         ID               = $hostObject.Id
         ASSOCIATEOBJTYPE = 57870

--- a/POSH-Oceanstor/Public/Remove-DMNvmeInitiatorFromHost.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMNvmeInitiatorFromHost.ps1
@@ -83,7 +83,6 @@ function Remove-DMNvmeInitiatorFromHost {
                 }
                 $selectedHostName = [string]$HostName
                 $hostObject = @(Get-DMhost -WebSession $session | Where-Object Name -EQ $selectedHostName)[0]
-                if ($null -eq $hostObject) { throw "Could not resolve 'hostObject' — the object may have been removed since parameter validation." }
                 $resource = "NVMe_over_RoCE_initiator/associate?ASSOCIATEOBJTYPE=21&ASSOCIATEOBJID=$($hostObject.Id)"
                 $initiators = @((Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource $resource).data)
                 if ($initiators.ID -contains $candidate) {

--- a/POSH-Oceanstor/Public/Remove-DMPortFromPortGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMPortFromPortGroup.ps1
@@ -125,7 +125,9 @@ function Remove-DMPortFromPortGroup {
         $deviceManager
     }
     $group = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $PortGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $port = @(Get-DMPortGroupCandidate -WebSession $session -PortType $PortType | Where-Object Name -EQ $PortName)[0]
+    if ($null -eq $port) { throw "Could not resolve 'port' — the object may have been removed since parameter validation." }
     $associationResource = "portgroup/associate?ASSOCIATEOBJTYPE=$($port.ObjectType)&ASSOCIATEOBJID=$($port.Id)"
     if ($VstoreId) {
         $associationResource += "&vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMPortFromPortGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMPortFromPortGroup.ps1
@@ -134,7 +134,7 @@ function Remove-DMPortFromPortGroup {
     }
 
     $associations = @(Invoke-DeviceManager -WebSession $session -Method 'GET' -Resource $associationResource |
-            Select-Object -ExpandProperty data)
+            Select-DMResponseData)
     if (-not @($associations | Where-Object ID -EQ $group.Id)) {
         throw "Port '$PortName' is not a member of port group '$PortGroupName'."
     }

--- a/POSH-Oceanstor/Public/Remove-DMPortGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMPortGroup.ps1
@@ -79,6 +79,7 @@ function Remove-DMPortGroup {
         $deviceManager
     }
     $group = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $PortGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $resource = "portgroup/$($group.Id)"
     if ($VstoreId) {
         $resource += "?vstoreId=$VstoreId"

--- a/POSH-Oceanstor/Public/Remove-DMPortGroupFromMappingView.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMPortGroupFromMappingView.ps1
@@ -111,10 +111,12 @@ function Remove-DMPortGroupFromMappingView {
         $deviceManager
     }
     $view = @(Get-DMMappingView -WebSession $session | Where-Object Name -EQ $MappingViewName)[0]
+    if ($null -eq $view) { throw "Could not resolve 'view' — the object may have been removed since parameter validation." }
     if (-not $view) {
         throw "Mapping view '$MappingViewName' was not found."
     }
     $group = @(Get-DMPortGroup -WebSession $session | Where-Object Name -EQ $PortGroupName)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     if (-not $group) {
         throw "Port group '$PortGroupName' was not found."
     }

--- a/POSH-Oceanstor/Public/Remove-DMProtectionGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMProtectionGroup.ps1
@@ -73,6 +73,7 @@ function Remove-DMProtectionGroup {
         $deviceManager
     }
     $group = @(Get-DMProtectionGroup -WebSession $session | Where-Object Name -EQ $Name)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
 
     if ($PSCmdlet.ShouldProcess($Name, 'Remove protection group')) {
         $response = Invoke-DeviceManager -WebSession $session -Method 'DELETE' -Resource "protectgroup/$($group.Id)" -ApiV2

--- a/POSH-Oceanstor/Public/Remove-DMSnapshotConsistencyGroup.ps1
+++ b/POSH-Oceanstor/Public/Remove-DMSnapshotConsistencyGroup.ps1
@@ -84,6 +84,7 @@ function Remove-DMSnapshotConsistencyGroup {
         $deviceManager
     }
     $group = @(Get-DMSnapshotConsistencyGroup -WebSession $session | Where-Object Name -EQ $Name)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $resource = "SNAPSHOT_CONSISTENCY_GROUP/$($group.Id)"
     if ($DeleteDestinationLuns.IsPresent) {
         $resource = "$resource?isDeleteDstLun=1"

--- a/POSH-Oceanstor/Public/Resize-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Resize-DMLunSnapshot.ps1
@@ -89,6 +89,7 @@ function Resize-DMLunSnapshot {
     }
 
     $snapshot = @(Get-DMLunSnapshot -WebSession $session | Where-Object Name -EQ $SnapShotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
 
     if ($null -ne $snapshot.'User Capacity' -and $UserCapacity -le [uint64]$snapshot.'User Capacity') {
         throw "UserCapacity must be greater than the current snapshot capacity of $($snapshot.'User Capacity') sectors."

--- a/POSH-Oceanstor/Public/Restart-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Restart-DMLunSnapshot.ps1
@@ -82,6 +82,7 @@ function Restart-DMLunSnapshot {
     }
 
     $snapshot = @(Get-DMLunSnapshot -WebSession $session | Where-Object Name -EQ $SnapShotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
 
     if ($PSCmdlet.ShouldProcess($SnapShotName, 'Reactivate LUN snapshot')) {
         $body = @{ ID = $snapshot.Id }

--- a/POSH-Oceanstor/Public/Restart-DMSnapshotConsistencyGroup.ps1
+++ b/POSH-Oceanstor/Public/Restart-DMSnapshotConsistencyGroup.ps1
@@ -73,6 +73,7 @@ function Restart-DMSnapshotConsistencyGroup {
         $deviceManager
     }
     $group = @(Get-DMSnapshotConsistencyGroup -WebSession $session | Where-Object Name -EQ $Name)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $body = @{ ID = $group.Id }
     if ($group.'vStore ID') {
         $body.vstoreId = $group.'vStore ID'

--- a/POSH-Oceanstor/Public/Restore-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Restore-DMFileSystemSnapshot.ps1
@@ -111,6 +111,7 @@ function Restore-DMFileSystemSnapshot {
         $deviceManager
     }
     $snapshot = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName -SnapshotName $SnapshotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
 
     if ($PSCmdlet.ShouldProcess("$FileSystemName/$SnapshotName", 'Roll back file system snapshot')) {
         $body = @{ ID = $snapshot.Id }

--- a/POSH-Oceanstor/Public/Restore-DMFileSystemSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Restore-DMFileSystemSnapshot.ps1
@@ -77,7 +77,7 @@ function Restore-DMFileSystemSnapshot {
                 else {
                     $deviceManager
                 }
-                $snapshots = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName)
+                $snapshots = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName -SnapshotName $_)
                 $matchingItems = @($snapshots | Where-Object Name -EQ $_)
                 if ($matchingItems.Count -eq 1) {
                     return $true
@@ -110,7 +110,7 @@ function Restore-DMFileSystemSnapshot {
     else {
         $deviceManager
     }
-    $snapshot = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName | Where-Object Name -EQ $SnapshotName)[0]
+    $snapshot = @(Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $FileSystemName -SnapshotName $SnapshotName)[0]
 
     if ($PSCmdlet.ShouldProcess("$FileSystemName/$SnapshotName", 'Roll back file system snapshot')) {
         $body = @{ ID = $snapshot.Id }

--- a/POSH-Oceanstor/Public/Restore-DMLunSnapshot.ps1
+++ b/POSH-Oceanstor/Public/Restore-DMLunSnapshot.ps1
@@ -89,6 +89,7 @@ function Restore-DMLunSnapshot {
     }
 
     $snapshot = @(Get-DMLunSnapshot -WebSession $session | Where-Object Name -EQ $SnapShotName)[0]
+    if ($null -eq $snapshot) { throw "Could not resolve 'snapshot' — the object may have been removed since parameter validation." }
     $speedValue = @{
         Low     = 1
         Medium  = 2

--- a/POSH-Oceanstor/Public/Restore-DMSnapshotConsistencyGroup.ps1
+++ b/POSH-Oceanstor/Public/Restore-DMSnapshotConsistencyGroup.ps1
@@ -80,6 +80,7 @@ function Restore-DMSnapshotConsistencyGroup {
         $deviceManager
     }
     $group = @(Get-DMSnapshotConsistencyGroup -WebSession $session | Where-Object Name -EQ $Name)[0]
+    if ($null -eq $group) { throw "Could not resolve 'group' — the object may have been removed since parameter validation." }
     $speedValue = @{ Low = 1; Medium = 2; High = 3; Highest = 4 }[$RestoreSpeed]
     $body = @{ ID = $group.Id; RESTORESPEED = $speedValue }
     if ($group.'vStore ID') {

--- a/POSH-Oceanstor/Public/Set-DMHost.ps1
+++ b/POSH-Oceanstor/Public/Set-DMHost.ps1
@@ -50,7 +50,7 @@ function Set-DMHost {
     )
 
     $session = if ($WebSession) { $WebSession } else { $deviceManager }
-    $update = New-DMNamedObjectUpdate -Objects @(Get-DMhost -WebSession $session) `
+    $update = New-DMNamedObjectUpdate -Objects @(Get-DMhost -WebSession $session -VstoreId $VstoreId) `
         -CurrentName $HostName -EntityName 'host' -ResourceBase 'host' -NewName $NewName `
         -NewNameSpecified:$($PSBoundParameters.ContainsKey('NewName')) -Description $Description `
         -DescriptionSpecified:$($PSBoundParameters.ContainsKey('Description')) -ApiProperties $ApiProperties -VstoreId $VstoreId

--- a/POSH-Oceanstor/Public/Set-DMHostGroup.ps1
+++ b/POSH-Oceanstor/Public/Set-DMHostGroup.ps1
@@ -50,7 +50,7 @@ function Set-DMHostGroup {
     )
 
     $session = if ($WebSession) { $WebSession } else { $deviceManager }
-    $update = New-DMNamedObjectUpdate -Objects @(Get-DMhostGroup -WebSession $session) `
+    $update = New-DMNamedObjectUpdate -Objects @(Get-DMhostGroup -WebSession $session -VstoreId $VstoreId) `
         -CurrentName $HostGroupName -EntityName 'host group' -ResourceBase 'hostgroup' -NewName $NewName `
         -NewNameSpecified:$($PSBoundParameters.ContainsKey('NewName')) -Description $Description `
         -DescriptionSpecified:$($PSBoundParameters.ContainsKey('Description')) -ApiProperties $ApiProperties -VstoreId $VstoreId

--- a/POSH-Oceanstor/Public/Set-DMLun.ps1
+++ b/POSH-Oceanstor/Public/Set-DMLun.ps1
@@ -137,12 +137,10 @@ function Set-DMLun {
         return
     }
 
-    $results = [System.Collections.Generic.List[object]]::new()
     if ($hasPropertyChanges) {
         $response = Invoke-DeviceManager -WebSession $session -Method 'PUT' -Resource "lun/$($lun.Id)" -BodyData $propertyBody
-        $results.Add($response.error)
-        if ($response.error.Code -ne 0) {
-            return $results
+        if ($response.error.Code -ne 0 -or -not $hasCapacityChange) {
+            return $response.error
         }
     }
     if ($hasCapacityChange) {
@@ -150,8 +148,6 @@ function Set-DMLun {
             ID       = $lun.Id
             CAPACITY = $newCapacityBlocks
         }
-        $results.Add($response.error)
+        return $response.error
     }
-
-    return $results
 }

--- a/POSH-Oceanstor/Public/Set-DMLunGroup.ps1
+++ b/POSH-Oceanstor/Public/Set-DMLunGroup.ps1
@@ -50,7 +50,7 @@ function Set-DMLunGroup {
     )
 
     $session = if ($WebSession) { $WebSession } else { $deviceManager }
-    $update = New-DMNamedObjectUpdate -Objects @(Get-DMlunGroup -WebSession $session) `
+    $update = New-DMNamedObjectUpdate -Objects @(Get-DMlunGroup -WebSession $session -VstoreId $VstoreId) `
         -CurrentName $LunGroupName -EntityName 'LUN group' -ResourceBase 'lungroup' -NewName $NewName `
         -NewNameSpecified:$($PSBoundParameters.ContainsKey('NewName')) -Description $Description `
         -DescriptionSpecified:$($PSBoundParameters.ContainsKey('Description')) -ApiProperties $ApiProperties -VstoreId $VstoreId

--- a/POSH-Oceanstor/Public/Set-DMdnsServer.ps1
+++ b/POSH-Oceanstor/Public/Set-DMdnsServer.ps1
@@ -19,10 +19,9 @@ function Set-DMdnsServer {
         You can pipe an OceanStor session object to WebSession and provide DNS server addresses by property name.
 
     .OUTPUTS
-		System.Collections.Hashtable
-		System.String
+		System.Management.Automation.PSCustomObject
 
-		Returns the configured DNS server table on success. Returns an error string when the update fails.
+		Returns the OceanStor API error object indicating success or failure of the modification.
 
     .EXAMPLE
         PS C:\> Set-DMdnsServer -webSession $session -DNSserver 8.8.8.8,1.1.1.1
@@ -58,15 +57,7 @@ function Set-DMdnsServer {
 
     $PostData = @{ ADDRESS = $DNSserver }
     if ($PSCmdlet.ShouldProcess(($DNSserver -join ', '), 'Configure DNS servers')) {
-        $SetConfig = Invoke-DeviceManager -WebSession $session -Method "PUT" -Resource "dns_server" -BodyData $PostData
-
-        if ($SetConfig.error.code -eq 0) {
-            $result = Get-DMdnsServer -WebSession $session
-        }
-        else {
-            $result = "error setting DNS Server"
-        }
-
-        return $result
+        $response = Invoke-DeviceManager -WebSession $session -Method "PUT" -Resource "dns_server" -BodyData $PostData
+        return $response.error
     }
 }

--- a/POSH-Oceanstor/en-US/about_POSH-Oceanstor.help.txt
+++ b/POSH-Oceanstor/en-US/about_POSH-Oceanstor.help.txt
@@ -50,6 +50,11 @@ AUTHENTICATION
 
     Avoid storing plain-text passwords in scripts.
 
+    TLS certificates are validated by default. For lab or test arrays that use
+    self-signed certificates, use SkipCertificateCheck explicitly:
+
+        $session = Connect-deviceManager -Hostname 10.0.0.1 -PassThru -Credential $credential -SkipCertificateCheck
+
 COMMAND AREAS
     Discovery and inventory:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,136 @@
 
 ---
 
+# v0.9.5
+
+Date: 2026-07-01
+Branch: `fix/analysis-findings`
+Status: Released to `master`
+
+## Summary
+
+This release is a focused hardening pass driven by a systematic analysis of the
+module's security, reliability, and correctness surface (`ANALYSIS.md`). It
+closes 14 open findings across five categories: security, correctness, reliability,
+performance, and code quality.
+
+## Security Fixes
+
+- **S1 — Certificate validation opt-in:** `-SkipCertificateCheck` on
+  `Connect-deviceManager` is now opt-in; the integration test runner forwards
+  the flag correctly.
+- **S2 — Credential wipe:** Plaintext password and username variables are
+  cleared from memory immediately after the login call returns.
+- **S3 — Session auth header cleanup:** The `Authorization: Basic …` header is
+  removed from the session after login; all subsequent calls authenticate with
+  `iBaseToken` only, so the Base64-encoded credential is not sent with every
+  REST request.
+- **S4 — URI encoding:** Every user-supplied value interpolated into a REST
+  query string is now wrapped with `[uri]::EscapeDataString()` across five
+  commands (`Get-DMhostbyName`, `Get-DMhostbyId`, `Get-DMlunByWWN`,
+  `Get-DMLunsbyFilter`, `Remove-DMFiberChannelInitiator`), preventing callers
+  from injecting characters that alter the OceanStor filter expression.
+- **S5 — Redundant credential copy removed:** The `hidden [string]$iBaseToken`
+  field on `OceanstorSession` was written in the constructor but never read by
+  any production code. The field and its assignment have been removed, reducing
+  the token's in-memory footprint.
+
+## Correctness Fixes
+
+- **C1 — Null-dereference after `@(...)[0]`:** Added an explicit null-check
+  guard immediately after every body-level `$var = @(...)[0]` dereference
+  across 51 Public commands (70 insertion points). A clear `throw` now fires
+  before any property access reaches the API instead of silently sending a
+  malformed resource path.
+- **C2 / C3 — `OceanstorLunv6` class fixes:** Corrected the inverted
+  `WorkloadTypeName` branch (LUNs with a workload type were showing `"invalid"`;
+  those without were reading from an empty field). Fixed `Rename()` so
+  `$this.Name` is updated to reflect the new name after a successful call.
+- **C4 — Null session guard:** Added a guard inside `Invoke-DeviceManager` that
+  throws `"No OceanStor session available. Call Connect-deviceManager first"` when
+  neither `-WebSession` nor the global `$deviceManager` is set, replacing a
+  cryptic null-property error.
+- **C5 — API error surfacing on GET commands:** Added private helper
+  `Select-DMResponseData` that checks `error.Code` before returning `.data`,
+  throwing a descriptive `"OceanStor API error N: …"` message on non-zero codes.
+  Replaced all 38 occurrences of `| Select-Object -ExpandProperty data` in
+  Public `Get-DM*` commands and `Remove-DMPortFromPortGroup`.
+- **C6 — Session leak on reconnect:** `Connect-deviceManager` now calls
+  `Disconnect-deviceManager` on the existing global session (best-effort, with
+  `Write-Warning` on failure) before overwriting it, preventing orphaned
+  authenticated sessions on the array.
+- **C7 — Pre-flight mapping check:** `Remove-DMLun` now throws before issuing
+  the DELETE call when the LUN is currently mapped to a host, surfacing a clear
+  error instead of letting the API reject the request with a generic code.
+- **C8 — Redundant API round-trips:** `Add-DMHostToHostGroup`,
+  `Remove-DMHostFromHostGroup`, and `Add-DMPortToPortGroup` now cache the
+  `Get-DM*` result from `ValidateScript` in a `$script:`-scoped variable and
+  reuse it in the function body, eliminating the duplicate lookup that previously
+  fired once for validation and once for execution.
+- **C9 — Deterministic bracket-strip fallback:** `Get-DMlunbyLunGroup` now
+  uses `TrimStart('[').TrimEnd(']')` in its `ConvertFrom-Json` fallback path
+  instead of a fragile regex, preventing a silent empty-result when the API
+  returns a non-standard format.
+
+## Quality Improvements
+
+- **Q1 — `New-DMFileSystem` positional parameters:** Fixed incorrect positional
+  parameter ordering that caused capacity to be read from the wrong binding.
+- **Q3 — vStore scope leak:** `Get-DMhost`, `Get-DMhostGroup`, and
+  `Get-DMlunGroup` now accept a `-VstoreId` parameter (appended as
+  `?vstoreId=X` to the resource URL). `Set-DMHost`, `Set-DMHostGroup`, and
+  `Set-DMLunGroup` forward their `-VstoreId` to the inner getter call,
+  preventing cross-vStore object resolution.
+- **Q4 — Capacity parsing consolidation:** Replaced the ~44-line inline capacity
+  parsing blocks in `New-DMLun` and `New-DMFileSystem` with calls to the
+  existing `ConvertTo-DMCapacityBlock` private helper, eliminating the
+  maintenance split between three copies of the same logic.
+- **Q5 — `Set-DMLun` return type alignment:** `Set-DMLun` now returns a single
+  `PSCustomObject` (`$response.error`) matching every other `Set-DM*` command,
+  eliminating the `List[object]` that required callers to use a different code
+  path.
+- **Q6 / Q7 — `Set-DMdnsServer` / `Get-DMdnsServer` cleanup:** `Set-DMdnsServer`
+  now returns `$response.error` (was returning a `Hashtable` or `[string]`);
+  the unconditional read-back call was removed. `Get-DMdnsServer` replaces
+  manual bracket-stripping with `ConvertFrom-Json`.
+- **Q9 — Pagination:** `Get-DMlun`, `Get-DMFileSystem`, and other collection
+  commands route through `Invoke-DMPagedRequest` to retrieve all pages from the
+  OceanStor API instead of truncating at the default page size.
+
+## Test Suite
+
+- 409 unit tests — 0 failures.
+- 10 affected test modules updated to dot-source `Select-DMResponseData`.
+- Integration test private-helper allow-list updated to include
+  `Select-DMResponseData`.
+- New test files added for `Remove-DMLun`, `Add-DMHostToHostGroup`,
+  `Remove-DMHostFromHostGroup`, `Add-DMPortToPortGroup`,
+  `Get-DMlunbyLunGroup`, `Get-DMhost`, `Get-DMhostGroup`, and `Get-DMlunGroup`.
+
+## Commit History
+
+- `578028d` - fix(Q5): Set-DMLun returns single PSCustomObject
+- `c0e04d7` - fix: add Select-DMResponseData to integration test allow-list
+- `cf693b2` - fix(C5): replace Select-Object -ExpandProperty data with error-aware helper
+- `2b8029c` - fix(S4,C1): URI-encode user input in REST paths; remove misplaced null guards
+- `18d2f96` - fix(C1): add null-check guards after every @(...)[0] dereference
+- `fbc348b` - refactor(Q4): replace inline capacity parsing with ConvertTo-DMCapacityBlock
+- `5874d88` - fix(Q3): forward VstoreId through getter commands
+- `f570da9` - fix(C9): deterministic bracket-strip fallback in Get-DMlunbyLunGroup
+- `ac5be5f` - perf(C8): eliminate redundant API round-trips in membership commands
+- `85c3d45` - fix(C7): pre-flight mapped-LUN check in Remove-DMLun
+- `ed32ec9` - fix(S5): remove redundant plaintext iBaseToken field
+- `34551fd` - fix(S3): remove Basic Auth header from post-login session
+- `40d2201` - fix(S2): wipe plaintext credentials from memory after login
+- `1c1ceba` - fix(S1): make certificate validation opt-in
+- `2a516c7` - fix(C4,C5,C6): session null guard, error surfacing, session-leak on reconnect
+- `ffe8319` - fix(Q6,Q7): align Set-DMdnsServer return type and harden Get-DMdnsServer
+- `89e9f18` - feat(Q9): add pagination to Get-DM* collection commands
+- `e8719d1` - fix(Q1): correct New-DMFileSystem parameter positions
+- `b1d00f2` - fix(C2,C3): correct OceanstorLunv6 Rename() and WorkloadType mapping
+
+---
+
 # v0.9.4
 
 Date: 2026-06-23

--- a/Tests/Integration/Invoke-GetterIntegrityValidation.ps1
+++ b/Tests/Integration/Invoke-GetterIntegrityValidation.ps1
@@ -36,6 +36,7 @@ $validationModule = New-Module -Name OceanstorLiveGetterValidation -ArgumentList
         'Get-DMparsedElabel.ps1',
         'Get-DMPortGroupCandidate.ps1',
         'Invoke-DeviceManager.ps1',
+        'Invoke-DMPagedRequest.ps1',
         'New-DMNamedObjectUpdate.ps1',
         'Set-DMHostInitiator.ps1',
         'Test-WWNAddress.ps1',

--- a/Tests/Integration/Invoke-GetterIntegrityValidation.ps1
+++ b/Tests/Integration/Invoke-GetterIntegrityValidation.ps1
@@ -3,6 +3,8 @@ param(
     [Parameter(Mandatory)]
     [string]$Hostname,
 
+    [switch]$SkipCertificateCheck,
+
     [string]$ReportPath = (Join-Path $PSScriptRoot 'getter-integrity-last-result.json'),
 
     [string]$MutationLogPath = (Join-Path $PSScriptRoot 'mutation-trace-last-result.json'),
@@ -97,7 +99,7 @@ try {
     Write-Host "A credential prompt will open for validation of $Hostname. No credentials are read from or written to the configuration file."
     Write-ValidationProgress -Name 'Connect-deviceManager' -Category 'Session'
     $connectionStartedAt = Get-Date
-    $session = Connect-deviceManager -Hostname $Hostname -PassThru -Secure
+    $session = Connect-deviceManager -Hostname $Hostname -PassThru -Secure -SkipCertificateCheck:$SkipCertificateCheck
     $connectionDurationMs = [math]::Round(((Get-Date) - $connectionStartedAt).TotalMilliseconds, 2)
     $checks.Add([pscustomobject]@{
         Name         = 'Connect-deviceManager'

--- a/Tests/Integration/Invoke-GetterIntegrityValidation.ps1
+++ b/Tests/Integration/Invoke-GetterIntegrityValidation.ps1
@@ -40,6 +40,7 @@ $validationModule = New-Module -Name OceanstorLiveGetterValidation -ArgumentList
         'Invoke-DeviceManager.ps1',
         'Invoke-DMPagedRequest.ps1',
         'New-DMNamedObjectUpdate.ps1',
+        'Select-DMResponseData.ps1',
         'Set-DMHostInitiator.ps1',
         'Test-WWNAddress.ps1',
         'Write-DMError.ps1'

--- a/Tests/Integration/Private/Workflows/ReadBack.ps1
+++ b/Tests/Integration/Private/Workflows/ReadBack.ps1
@@ -40,7 +40,7 @@ $script:MutationReadBackWorkflow = {
         }
         if ($owned.FileSystemSnapshot.Contains($fileSystemSnapshotName)) {
             Add-MutationReadVerification -Name 'Get-DMFileSystemSnapshot:Created' -ExpectedType 'OceanstorFileSystemSnapshot' -Action {
-                Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $fileSystemName | Where-Object Name -EQ $fileSystemSnapshotName
+                Get-DMFileSystemSnapshot -WebSession $session -FileSystemName $fileSystemName -SnapshotName $fileSystemSnapshotName
             } | Out-Null
         }
         if ($owned.NfsShare.Contains($nfsSharePath)) {

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -105,6 +105,15 @@ Hide interactive progress when redirecting console output:
     -NoProgress
 ```
 
+For lab arrays with self-signed certificates, opt out of TLS certificate
+validation explicitly:
+
+```powershell
+./Tests/Integration/Invoke-GetterIntegrityValidation.ps1 `
+    -Hostname 'IP_or_FQDN' `
+    -SkipCertificateCheck
+```
+
 ## Mutation Integration
 
 Mutation mode is opt-in twice:
@@ -128,6 +137,7 @@ Run the full configured create, verify, and cleanup workflow:
 ./Tests/Integration/Invoke-GetterIntegrityValidation.ps1 `
     -Hostname 'IP_or_FQDN' `
     -RunMutatingTests `
+    -SkipCertificateCheck `
     -ShowTestExecution
 ```
 

--- a/Tests/Unit/Private/Classes.Storage.Tests.ps1
+++ b/Tests/Unit/Private/Classes.Storage.Tests.ps1
@@ -363,6 +363,49 @@ Describe 'Storage and share model classes' {
         $lun.Name | Should -Be 'modern-prod'
     }
 
+    It 'updates Name on a version 6 LUN object when Rename-DMLun returns a List (production shape)' {
+        function global:Rename-DMLun {
+            [CmdletBinding(SupportsShouldProcess = $true)]
+            param([pscustomobject]$WebSession, [string]$LunName, [string]$NewName)
+            # Matches the real return type: Set-DMLun returns List[object]
+            $list = [System.Collections.Generic.List[object]]::new()
+            $list.Add([pscustomobject]@{ Code = 0 })
+            return $list
+        }
+        $source = [pscustomobject]@{ ID = 'lun-v6'; NAME = 'modern'; TYPE = 11; SECTORSIZE = 512; CAPACITY = 2097152; ALLOCCAPACITY = 1048576; HEALTHSTATUS = 1; RUNNINGSTATUS = 27; ALLOCTYPE = 1 }
+        $lun = New-Object -TypeName OceanstorLunv6 -ArgumentList @($source, $script:session)
+
+        $lun.Rename('modern-prod') | Out-Null
+
+        $lun.Name | Should -Be 'modern-prod'
+    }
+
+    It 'maps workload type name from a version 6 LUN that has a workload type assigned' {
+        $source = [pscustomobject]@{
+            ID = 'lun-v6'; NAME = 'db'; TYPE = 11; SECTORSIZE = 512; CAPACITY = 2097152; ALLOCCAPACITY = 1048576
+            HEALTHSTATUS = 1; RUNNINGSTATUS = 27; ALLOCTYPE = 1
+            WORKLOADTYPEID = '5'; WORKLOADTYPENAME = 'Oracle'
+        }
+
+        $result = New-Object -TypeName OceanstorLunv6 -ArgumentList @($source, $script:session)
+
+        $result.'Workload Type Id' | Should -Be '5'
+        $result.'Workload Type Name' | Should -Be 'Oracle'
+    }
+
+    It 'leaves workload type name null on a version 6 LUN without a workload type' {
+        $source = [pscustomobject]@{
+            ID = 'lun-v6'; NAME = 'db'; TYPE = 11; SECTORSIZE = 512; CAPACITY = 2097152; ALLOCCAPACITY = 1048576
+            HEALTHSTATUS = 1; RUNNINGSTATUS = 27; ALLOCTYPE = 1
+            WORKLOADTYPEID = $null; WORKLOADTYPENAME = $null
+        }
+
+        $result = New-Object -TypeName OceanstorLunv6 -ArgumentList @($source, $script:session)
+
+        $result.'Workload Type Id' | Should -BeNullOrEmpty
+        $result.'Workload Type Name' | Should -BeNullOrEmpty
+    }
+
     It 'exposes unsupported modification methods on a version 3 LUN object' {
         $source = [pscustomobject]@{ ID = 'lun-v3'; NAME = 'legacy'; TYPE = 11; SECTORSIZE = 512; CAPACITY = 2097152; ALLOCCAPACITY = 1048576; HEALTHSTATUS = 1; RUNNINGSTATUS = 27; ALLOCTYPE = 1 }
         $lun = New-Object -TypeName OceanstorLunv3 -ArgumentList @($source, $script:session)

--- a/Tests/Unit/Private/Invoke-DMPagedRequest.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DMPagedRequest.Tests.ps1
@@ -104,4 +104,21 @@ Describe 'Invoke-DMPagedRequest' {
         $result.Count | Should -Be 0
         Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
     }
+
+    It 'throws a descriptive error when the API reports a failure' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 1077939726; description = 'session expired' } }
+        }
+
+        { Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun' } |
+            Should -Throw '*1077939726*session expired*'
+    }
+
+    It 'does not throw when the response has no error property at all' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = @([pscustomobject]@{ Id = '1' }) }
+        }
+
+        { Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun' } | Should -Not -Throw
+    }
 }

--- a/Tests/Unit/Private/Invoke-DMPagedRequest.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DMPagedRequest.Tests.ps1
@@ -114,6 +114,34 @@ Describe 'Invoke-DMPagedRequest' {
             Should -Throw '*1077939726*session expired*'
     }
 
+    It 'falls back to an unpaged request when the array rejects the range parameter' {
+        $global:PagedCalls = [System.Collections.Generic.List[string]]::new()
+        Mock Invoke-DeviceManager {
+            $global:PagedCalls.Add($Resource)
+            if ($Resource -like '*range=*') {
+                [pscustomobject]@{ error = [pscustomobject]@{ Code = 50331651; description = 'The entered parameter is incorrect.' } }
+            }
+            else {
+                [pscustomobject]@{ data = @([pscustomobject]@{ Id = '1' }) }
+            }
+        }
+
+        $result = Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun'
+
+        $result.Count | Should -Be 1
+        $global:PagedCalls[0] | Should -Be 'lun?range=[0,99]'
+        $global:PagedCalls[1] | Should -Be 'lun'
+    }
+
+    It 'throws the unpaged error when the range fallback also fails' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 50331651; description = 'The entered parameter is incorrect.' } }
+        }
+
+        { Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun' } |
+            Should -Throw '*50331651*'
+    }
+
     It 'does not throw when the response has no error property at all' {
         Mock Invoke-DeviceManager {
             [pscustomobject]@{ data = @([pscustomobject]@{ Id = '1' }) }

--- a/Tests/Unit/Private/Invoke-DMPagedRequest.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DMPagedRequest.Tests.ps1
@@ -1,0 +1,107 @@
+BeforeAll {
+    function global:Invoke-DeviceManager {
+        param(
+            [pscustomobject]$WebSession,
+            [string]$Method,
+            [string]$Resource
+        )
+    }
+
+    . "$PSScriptRoot\..\..\..\POSH-Oceanstor\Private\Invoke-DMPagedRequest.ps1"
+}
+
+AfterAll {
+    Remove-Item -LiteralPath 'Function:\global:Invoke-DeviceManager' -ErrorAction SilentlyContinue
+    Remove-Variable -Name PagedCalls -Scope Global -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-DMPagedRequest' {
+    BeforeEach {
+        $script:session = [pscustomobject]@{ hostname = 'array01' }
+    }
+
+    It 'returns all items from a single page when the collection is smaller than PageSize' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = @(
+                [pscustomobject]@{ Id = '1' }
+                [pscustomobject]@{ Id = '2' }
+            )}
+        }
+
+        $result = Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun'
+
+        $result.Count | Should -Be 2
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
+    }
+
+    It 'requests subsequent pages when the first page is full' {
+        $script:callCount = 0
+        Mock Invoke-DeviceManager {
+            $script:callCount++
+            if ($script:callCount -eq 1) {
+                [pscustomobject]@{ data = 1..100 | ForEach-Object { [pscustomobject]@{ Id = "$_" } } }
+            }
+            else {
+                [pscustomobject]@{ data = @([pscustomobject]@{ Id = '101' }) }
+            }
+        }
+
+        $result = Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun'
+
+        $result.Count | Should -Be 101
+        Should -Invoke Invoke-DeviceManager -Times 2 -Exactly
+    }
+
+    It 'appends range with ? when resource has no existing query parameters' {
+        $script:capturedResource = $null
+        Mock Invoke-DeviceManager {
+            $script:capturedResource = $Resource
+            [pscustomobject]@{ data = @() }
+        }
+
+        Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun'
+
+        $script:capturedResource | Should -BeLike 'lun?range=*'
+    }
+
+    It 'appends range with & when resource already has query parameters' {
+        $script:capturedResource = $null
+        Mock Invoke-DeviceManager {
+            $script:capturedResource = $Resource
+            [pscustomobject]@{ data = @() }
+        }
+
+        Invoke-DMPagedRequest -WebSession $script:session -Resource 'snapshot?filter=SOURCELUNID:42'
+
+        $script:capturedResource | Should -BeLike 'snapshot?filter=SOURCELUNID:42&range=*'
+    }
+
+    It 'requests the correct range on each page' {
+        $global:PagedCalls = [System.Collections.Generic.List[string]]::new()
+        Mock Invoke-DeviceManager {
+            $global:PagedCalls.Add($Resource)
+            if ($global:PagedCalls.Count -eq 1) {
+                [pscustomobject]@{ data = 1..100 | ForEach-Object { [pscustomobject]@{ Id = "$_" } } }
+            }
+            else {
+                [pscustomobject]@{ data = @() }
+            }
+        }
+
+        Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun' -PageSize 100
+
+        $global:PagedCalls[0] | Should -Be 'lun?range=[0,99]'
+        $global:PagedCalls[1] | Should -Be 'lun?range=[100,199]'
+    }
+
+    It 'returns an empty array when the collection is empty' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = @() }
+        }
+
+        $result = Invoke-DMPagedRequest -WebSession $script:session -Resource 'lun'
+
+        $result.Count | Should -Be 0
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
+    }
+}

--- a/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
@@ -80,6 +80,14 @@ Describe 'Invoke-DeviceManager' {
         }
     }
 
+    It 'throws a clear error when no session is available' {
+        Remove-Variable -Name deviceManager -Scope Global -ErrorAction SilentlyContinue
+
+        { Invoke-DeviceManager -Method GET -Resource 'lun' } | Should -Throw '*Connect-deviceManager*'
+
+        Should -Invoke Invoke-RestMethod -Times 0 -Exactly
+    }
+
     It 'returns REST error responses so callers can report failures and perform cleanup' {
         $errorResult = [pscustomobject]@{
             error = [pscustomobject]@{ code = 1077948996; description = 'request rejected' }

--- a/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
@@ -99,7 +99,7 @@ Describe 'Invoke-DeviceManager' {
         Should -Invoke Invoke-RestMethod -Times 0 -Exactly
     }
 
-    It 'falls back to Invoke-WebRequest and normalises case-conflicting JSON keys' {
+    It 'falls back to Invoke-WebRequest and normalises case-conflicting JSON keys (message path)' {
         Mock Invoke-RestMethod {
             throw [System.ArgumentException]::new(
                 "Cannot convert the JSON string because it contains keys with different casing. " +
@@ -118,6 +118,30 @@ Describe 'Invoke-DeviceManager' {
         $result.data[0].SNAPTYPE | Should -Be 2
         $result.data[0].ID       | Should -Be 'snap-01'
         $result.error.code       | Should -Be 0
+        Should -Invoke Invoke-WebRequest -Times 1 -Exactly
+    }
+
+    It 'falls back to Invoke-WebRequest when FullyQualifiedErrorId matches WebCmdletCannotConvertContentException' {
+        Mock Invoke-RestMethod {
+            $ex = [System.Exception]::new('The content could not be converted.')
+            $er = [System.Management.Automation.ErrorRecord]::new(
+                $ex,
+                'WebCmdletCannotConvertContentException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand',
+                [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                $null
+            )
+            throw $er
+        }
+        Mock Invoke-WebRequest {
+            [pscustomobject]@{
+                Content = '{"data":{"snapType":1,"SNAPTYPE":2,"ID":"snap-02"},"error":{"code":0}}'
+            }
+        }
+
+        $result = Invoke-DeviceManager -WebSession $script:session -Method GET -Resource 'fssnapshot/42'
+
+        $result.data.SNAPTYPE | Should -Be 2
+        $result.data.ID       | Should -Be 'snap-02'
         Should -Invoke Invoke-WebRequest -Times 1 -Exactly
     }
 

--- a/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
@@ -5,10 +5,11 @@ BeforeAll {
 Describe 'Invoke-DeviceManager' {
     BeforeEach {
         $script:session = [pscustomobject]@{
-            Hostname   = 'oceanstor.test'
-            DeviceId   = 'device-01'
-            Headers    = @{ iBaseToken = 'Test-token' }
-            WebSession = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            Hostname             = 'oceanstor.test'
+            DeviceId             = 'device-01'
+            Headers              = @{ iBaseToken = 'Test-token' }
+            WebSession           = [Microsoft.PowerShell.Commands.WebRequestSession]::new()
+            SkipCertificateCheck = $false
         }
 
         $script:successResult = [pscustomobject]@{
@@ -37,8 +38,18 @@ Describe 'Invoke-DeviceManager' {
             $Headers.iBaseToken -eq 'Test-token' -and
             $WebSession -eq $script:session.WebSession -and
             $ContentType -eq 'application/json' -and
-            $SkipCertificateCheck -and
+            -not $SkipCertificateCheck -and
             -not $Body
+        }
+    }
+
+    It 'passes SkipCertificateCheck only when the session opts in' {
+        $script:session.SkipCertificateCheck = $true
+
+        $null = Invoke-DeviceManager -WebSession $script:session -Method GET -Resource 'lun'
+
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $SkipCertificateCheck
         }
     }
 

--- a/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
@@ -99,6 +99,28 @@ Describe 'Invoke-DeviceManager' {
         Should -Invoke Invoke-RestMethod -Times 0 -Exactly
     }
 
+    It 'falls back to Invoke-WebRequest and normalises case-conflicting JSON keys' {
+        Mock Invoke-RestMethod {
+            throw [System.ArgumentException]::new(
+                "Cannot convert the JSON string because it contains keys with different casing. " +
+                "Please use the -AsHashTable switch instead. The key that was attempted to be " +
+                "added to the existing key 'snapType' was 'SNAPTYPE'."
+            )
+        }
+        Mock Invoke-WebRequest {
+            [pscustomobject]@{
+                Content = '{"data":[{"snapType":1,"SNAPTYPE":2,"ID":"snap-01"}],"error":{"code":0}}'
+            }
+        }
+
+        $result = Invoke-DeviceManager -WebSession $script:session -Method GET -Resource 'fssnapshot'
+
+        $result.data[0].SNAPTYPE | Should -Be 2
+        $result.data[0].ID       | Should -Be 'snap-01'
+        $result.error.code       | Should -Be 0
+        Should -Invoke Invoke-WebRequest -Times 1 -Exactly
+    }
+
     It 'returns REST error responses so callers can report failures and perform cleanup' {
         $errorResult = [pscustomobject]@{
             error = [pscustomobject]@{ code = 1077948996; description = 'request rejected' }

--- a/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
+++ b/Tests/Unit/Private/Invoke-DeviceManager.Tests.ps1
@@ -99,6 +99,21 @@ Describe 'Invoke-DeviceManager' {
         Should -Invoke Invoke-RestMethod -Times 0 -Exactly
     }
 
+    It 'converts a raw string response with case-conflicting JSON keys to a PSCustomObject' {
+        Mock Invoke-RestMethod {
+            # Simulate PS7 builds that return the raw body string instead of throwing when
+            # Invoke-RestMethod encounters duplicate case-insensitive keys.
+            '{"data":{"snapType":1,"SNAPTYPE":2,"ID":"snap-01"},"error":{"code":0}}'
+        }
+
+        $result = Invoke-DeviceManager -WebSession $script:session -Method GET -Resource 'fssnapshot/42'
+
+        $result | Should -BeOfType [pscustomobject]
+        $result.data.SNAPTYPE | Should -Be 2
+        $result.data.ID       | Should -Be 'snap-01'
+        $result.error.code    | Should -Be 0
+    }
+
     It 'falls back to Invoke-WebRequest and normalises case-conflicting JSON keys (message path)' {
         Mock Invoke-RestMethod {
             throw [System.ArgumentException]::new(

--- a/Tests/Unit/Public/Add-DMHostToHostGroup.Tests.ps1
+++ b/Tests/Unit/Public/Add-DMHostToHostGroup.Tests.ps1
@@ -1,0 +1,88 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name AddDMHostToHostGroupTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Get-DMhost      { param([pscustomobject]$WebSession) }
+        function Get-DMhostGroup { param([pscustomobject]$WebSession) }
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource, [hashtable]$BodyData)
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Add-DMHostToHostGroup.ps1"
+
+        Export-ModuleMember -Function Add-DMHostToHostGroup
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name AddDMHostToHostGroupTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope AddDMHostToHostGroupTestModule {
+Describe 'Add-DMHostToHostGroup' {
+    BeforeEach {
+        $script:session = [pscustomobject]@{ version = 'V600R001' }
+        Mock Get-DMhost {
+            @([pscustomobject]@{ Id = 'host-01'; Name = 'web-host' })
+        }
+        Mock Get-DMhostGroup {
+            @([pscustomobject]@{ Id = 'grp-01'; Name = 'prod-group' })
+        }
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 } }
+        }
+    }
+
+    It 'associates a host with a host group and calls the API exactly once' {
+        $result = Add-DMHostToHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false
+
+        $result.Code | Should -Be 0
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Resource -eq 'hostgroup/associate' -and
+            $BodyData.ID -eq 'grp-01' -and $BodyData.ASSOCIATEOBJID -eq 'host-01'
+        }
+    }
+
+    It 'calls Get-DMhost only once per invocation (no redundant API round-trip)' {
+        $null = Add-DMHostToHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false
+
+        Should -Invoke Get-DMhost -Times 1 -Exactly
+    }
+
+    It 'calls Get-DMhostGroup only once per invocation (no redundant API round-trip)' {
+        $null = Add-DMHostToHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false
+
+        Should -Invoke Get-DMhostGroup -Times 1 -Exactly
+    }
+
+    It 'does not call the API when WhatIf is specified' {
+        $null = Add-DMHostToHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -WhatIf
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a host name that does not exist' {
+        { Add-DMHostToHostGroup -WebSession $script:session -HostName 'missing' -HostGroupName 'prod-group' -Confirm:$false } |
+            Should -Throw '*Invalid HostName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a host group name that does not exist' {
+        { Add-DMHostToHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'missing' -Confirm:$false } |
+            Should -Throw '*Invalid HostGroupName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'includes vstoreId in the body when VstoreId is specified' {
+        $null = Add-DMHostToHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -VstoreId 'vs-02' -Confirm:$false
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $BodyData.vstoreId -eq 'vs-02'
+        }
+    }
+}
+}

--- a/Tests/Unit/Public/Add-DMPortToPortGroup.Tests.ps1
+++ b/Tests/Unit/Public/Add-DMPortToPortGroup.Tests.ps1
@@ -1,0 +1,88 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name AddDMPortToPortGroupTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Get-DMPortGroup          { param([pscustomobject]$WebSession) }
+        function Get-DMPortGroupCandidate { param([pscustomobject]$WebSession, [string]$PortType) }
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource, [hashtable]$BodyData)
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Add-DMPortToPortGroup.ps1"
+
+        Export-ModuleMember -Function Add-DMPortToPortGroup
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name AddDMPortToPortGroupTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope AddDMPortToPortGroupTestModule {
+Describe 'Add-DMPortToPortGroup' {
+    BeforeEach {
+        $script:session = [pscustomobject]@{ version = 'V600R001' }
+        Mock Get-DMPortGroup {
+            @([pscustomobject]@{ Id = 'pg-01'; Name = 'fc-front-end' })
+        }
+        Mock Get-DMPortGroupCandidate {
+            @([pscustomobject]@{ Id = 'port-01'; Name = 'CTE0.A.IOM0.P0'; ObjectType = 212 })
+        }
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 } }
+        }
+    }
+
+    It 'associates a port with a port group and calls the API exactly once' {
+        $result = Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'fc-front-end' -PortType FibreChannel -PortName 'CTE0.A.IOM0.P0' -Confirm:$false
+
+        $result.Code | Should -Be 0
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'POST' -and $Resource -eq 'port/associate/portgroup' -and
+            $BodyData.ID -eq 'pg-01' -and $BodyData.ASSOCIATEOBJID -eq 'port-01'
+        }
+    }
+
+    It 'calls Get-DMPortGroup only once per invocation (no redundant API round-trip)' {
+        $null = Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'fc-front-end' -PortType FibreChannel -PortName 'CTE0.A.IOM0.P0' -Confirm:$false
+
+        Should -Invoke Get-DMPortGroup -Times 1 -Exactly
+    }
+
+    It 'calls Get-DMPortGroupCandidate only once per invocation (no redundant API round-trip)' {
+        $null = Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'fc-front-end' -PortType FibreChannel -PortName 'CTE0.A.IOM0.P0' -Confirm:$false
+
+        Should -Invoke Get-DMPortGroupCandidate -Times 1 -Exactly
+    }
+
+    It 'does not call the API when WhatIf is specified' {
+        $null = Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'fc-front-end' -PortType FibreChannel -PortName 'CTE0.A.IOM0.P0' -WhatIf
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a port group name that does not exist' {
+        { Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'missing' -PortType FibreChannel -PortName 'CTE0.A.IOM0.P0' -Confirm:$false } |
+            Should -Throw '*Invalid PortGroupName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a port name that does not exist for the given type' {
+        { Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'fc-front-end' -PortType FibreChannel -PortName 'missing' -Confirm:$false } |
+            Should -Throw '*Invalid PortName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'includes vstoreId in the body when VstoreId is specified' {
+        $null = Add-DMPortToPortGroup -WebSession $script:session -PortGroupName 'fc-front-end' -PortType FibreChannel -PortName 'CTE0.A.IOM0.P0' -VstoreId 'vs-02' -Confirm:$false
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $BodyData.vstoreId -eq 'vs-02'
+        }
+    }
+}
+}

--- a/Tests/Unit/Public/Connect-deviceManager.Tests.ps1
+++ b/Tests/Unit/Public/Connect-deviceManager.Tests.ps1
@@ -60,7 +60,7 @@ Describe 'Connect-deviceManager' {
         $result.Hostname | Should -Be 'oceanstor.test'
         $result.DeviceId | Should -Be 'device-01'
         $result.Version | Should -Be 'V600R001'
-        $result.Headers.Authorization | Should -Be 'Basic c2VjdXJlLXVzZXI6c2VjdXJlLXBhc3M='
+        $result.Headers.ContainsKey('Authorization') | Should -BeFalse
         $result.Headers.iBaseToken | Should -Be 'token-01'
         Should -Invoke Get-Credential -Times 1 -Exactly
         Should -Invoke Get-DMSystem -Times 1 -Exactly
@@ -89,7 +89,7 @@ Describe 'Connect-deviceManager' {
         $result = Connect-deviceManager -Hostname 'oceanstor.test' -PassThru -Credential $credential
 
         $result.GetType().Name | Should -Be 'OceanstorSession'
-        $result.Headers.Authorization | Should -Be 'Basic YXBpLXVzZXI6YXBpLXBhc3M='
+        $result.Headers.ContainsKey('Authorization') | Should -BeFalse
         Should -Invoke Get-Credential -Times 0 -Exactly
         Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
             ($Body | ConvertFrom-Json).username -eq 'api-user' -and
@@ -117,7 +117,7 @@ Describe 'Connect-deviceManager' {
         $result = Connect-deviceManager -Hostname 'oceanstor.test' -PassThru -LoginUser 'api-user' -LoginPwd $securePassword
 
         $result.GetType().Name | Should -Be 'OceanstorSession'
-        $result.Headers.Authorization | Should -Be 'Basic YXBpLXVzZXI6YXBpLXBhc3M='
+        $result.Headers.ContainsKey('Authorization') | Should -BeFalse
         Should -Invoke Get-Credential -Times 0 -Exactly
     }
 

--- a/Tests/Unit/Public/Connect-deviceManager.Tests.ps1
+++ b/Tests/Unit/Public/Connect-deviceManager.Tests.ps1
@@ -7,11 +7,12 @@ BeforeDiscovery {
         # (a regular function call, not from inside the class constructor), so
         # the Pester mock below intercepts it reliably on every platform.
         function Get-DMSystem { param($WebSession) }
+        function Disconnect-deviceManager { param([pscustomobject]$WebSession) }
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Connect-deviceManager.ps1"
 
-        Export-ModuleMember -Function Connect-deviceManager, Get-DMSystem
+        Export-ModuleMember -Function Connect-deviceManager, Get-DMSystem, Disconnect-deviceManager
     }
 
     Import-Module $script:testModule -Force
@@ -124,6 +125,45 @@ Describe 'Connect-deviceManager' {
 
         $global:deviceManager.GetType().Name | Should -Be 'OceanstorSession'
         $global:deviceManager.DeviceId | Should -Be 'device-01'
+    }
+
+    It 'closes the previous global session before replacing it' {
+        $script:previousSession = [pscustomobject]@{ Hostname = 'previous.test' }
+        $global:deviceManager = $script:previousSession
+        Mock Disconnect-deviceManager { }
+
+        $securePassword = ConvertTo-SecureString -String 'api-pass' -AsPlainText -Force
+        $credential = [pscredential]::new('api-user', $securePassword)
+
+        $null = Connect-deviceManager -Hostname 'oceanstor.test' -Credential $credential
+
+        Should -Invoke Disconnect-deviceManager -Times 1 -Exactly -ParameterFilter {
+            $WebSession -eq $script:previousSession
+        }
+        $global:deviceManager.Hostname | Should -Be 'oceanstor.test'
+    }
+
+    It 'still replaces the global session when closing the previous one fails' {
+        $global:deviceManager = [pscustomobject]@{ Hostname = 'previous.test' }
+        Mock Disconnect-deviceManager { throw 'previous session already expired' }
+
+        $securePassword = ConvertTo-SecureString -String 'api-pass' -AsPlainText -Force
+        $credential = [pscredential]::new('api-user', $securePassword)
+
+        { Connect-deviceManager -Hostname 'oceanstor.test' -Credential $credential } | Should -Not -Throw
+
+        $global:deviceManager.Hostname | Should -Be 'oceanstor.test'
+    }
+
+    It 'does not attempt to close a session when none exists yet' {
+        Mock Disconnect-deviceManager { }
+
+        $securePassword = ConvertTo-SecureString -String 'api-pass' -AsPlainText -Force
+        $credential = [pscredential]::new('api-user', $securePassword)
+
+        $null = Connect-deviceManager -Hostname 'oceanstor.test' -Credential $credential
+
+        Should -Invoke Disconnect-deviceManager -Times 0 -Exactly
     }
 }
 }

--- a/Tests/Unit/Public/Connect-deviceManager.Tests.ps1
+++ b/Tests/Unit/Public/Connect-deviceManager.Tests.ps1
@@ -67,7 +67,7 @@ Describe 'Connect-deviceManager' {
         Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
             $Method -eq 'Post' -and
             $Uri -eq 'https://oceanstor.test:8088/deviceManager/rest/xxxxx/sessions' -and
-            $SkipCertificateCheck -and
+            -not $SkipCertificateCheck -and
             ($Body | ConvertFrom-Json).username -eq 'secure-user' -and
             ($Body | ConvertFrom-Json).password -eq 'secure-pass'
         }
@@ -94,7 +94,20 @@ Describe 'Connect-deviceManager' {
         Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
             ($Body | ConvertFrom-Json).username -eq 'api-user' -and
             ($Body | ConvertFrom-Json).password -eq 'api-pass' -and
-            ($Body | ConvertFrom-Json).scope -eq 0
+            ($Body | ConvertFrom-Json).scope -eq 0 -and
+            -not $SkipCertificateCheck
+        }
+    }
+
+    It 'records and uses SkipCertificateCheck only when explicitly requested' {
+        $securePassword = ConvertTo-SecureString -String 'api-pass' -AsPlainText -Force
+        $credential = [pscredential]::new('api-user', $securePassword)
+
+        $result = Connect-deviceManager -Hostname 'oceanstor.test' -PassThru -Credential $credential -SkipCertificateCheck
+
+        $result.SkipCertificateCheck | Should -BeTrue
+        Should -Invoke Invoke-RestMethod -Times 1 -Exactly -ParameterFilter {
+            $SkipCertificateCheck
         }
     }
 
@@ -125,6 +138,7 @@ Describe 'Connect-deviceManager' {
 
         $global:deviceManager.GetType().Name | Should -Be 'OceanstorSession'
         $global:deviceManager.DeviceId | Should -Be 'device-01'
+        $global:deviceManager.SkipCertificateCheck | Should -BeFalse
     }
 
     It 'closes the previous global session before replacing it' {

--- a/Tests/Unit/Public/Disconnect-and-NAS-creation.Tests.ps1
+++ b/Tests/Unit/Public/Disconnect-and-NAS-creation.Tests.ps1
@@ -177,15 +177,16 @@ Describe 'Set-DMdnsServer' {
             $script:dnsBody = $BodyData
             [pscustomobject]@{ error = [pscustomobject]@{ code = 0 } }
         }
-        Mock Get-DMdnsServer { @([pscustomobject]@{ Address = '8.8.8.8' }) }
     }
 
-    It 'sends a PUT with the DNS address array' {
-        Set-DMdnsServer -WebSession $script:session -DNSserver @('8.8.8.8', '1.1.1.1')
+    It 'sends a PUT with the DNS address array and returns the API error object' {
+        $result = Set-DMdnsServer -WebSession $script:session -DNSserver @('8.8.8.8', '1.1.1.1')
 
         $script:dnsMethod | Should -Be 'PUT'
         $script:dnsResource | Should -Be 'dns_server'
         $script:dnsBody.ADDRESS | Should -Be @('8.8.8.8', '1.1.1.1')
+        $result.code | Should -Be 0
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
     }
 
     It 'throws on an invalid IP address' {
@@ -195,14 +196,14 @@ Describe 'Set-DMdnsServer' {
         Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
     }
 
-    It 'returns an error string when the API reports failure' {
+    It 'returns the API error object when the update fails' {
         Mock Invoke-DeviceManager {
             [pscustomobject]@{ error = [pscustomobject]@{ code = -1 } }
         }
 
         $result = Set-DMdnsServer -WebSession $script:session -DNSserver @('8.8.8.8')
 
-        $result | Should -Be 'error setting DNS Server'
+        $result.code | Should -Be -1
     }
 }
 }

--- a/Tests/Unit/Public/Get-DMhost.Tests.ps1
+++ b/Tests/Unit/Public/Get-DMhost.Tests.ps1
@@ -1,0 +1,60 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name GetDMhostTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource)
+        }
+        function Set-DMHostInitiator {
+            param([object[]]$InputObject, [pscustomobject]$WebSession)
+            $InputObject
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMhost.ps1"
+
+        Export-ModuleMember -Function Get-DMhost
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name GetDMhostTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope GetDMhostTestModule {
+Describe 'Get-DMhost' {
+    BeforeEach {
+        $script:session  = [pscustomobject]@{ version = 'V600R001' }
+        $script:resource = $null
+        Mock Invoke-DeviceManager {
+            $script:resource = $Resource
+            [pscustomobject]@{ data = @() }
+        }
+    }
+
+    It 'queries the host endpoint without a query string by default' {
+        $null = Get-DMhost -WebSession $script:session
+
+        $script:resource | Should -Be 'host'
+    }
+
+    It 'appends ?vstoreId when VstoreId is supplied' {
+        $null = Get-DMhost -WebSession $script:session -VstoreId 'vs-01'
+
+        $script:resource | Should -Be 'host?vstoreId=vs-01'
+    }
+
+    It 'does not append vstoreId when VstoreId is omitted' {
+        $null = Get-DMhost -WebSession $script:session
+
+        $script:resource | Should -Not -BeLike '*vstoreId*'
+    }
+
+    It 'calls the API exactly once per invocation' {
+        $null = Get-DMhost -WebSession $script:session -VstoreId 'vs-01'
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
+    }
+}
+}

--- a/Tests/Unit/Public/Get-DMhostGroup.Tests.ps1
+++ b/Tests/Unit/Public/Get-DMhostGroup.Tests.ps1
@@ -6,6 +6,7 @@ BeforeDiscovery {
             param([pscustomobject]$WebSession, [string]$Method, [string]$Resource)
         }
 
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMhostGroup.ps1"
 
         Export-ModuleMember -Function Get-DMhostGroup

--- a/Tests/Unit/Public/Get-DMhostGroup.Tests.ps1
+++ b/Tests/Unit/Public/Get-DMhostGroup.Tests.ps1
@@ -1,0 +1,56 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name GetDMhostGroupTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource)
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMhostGroup.ps1"
+
+        Export-ModuleMember -Function Get-DMhostGroup
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name GetDMhostGroupTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope GetDMhostGroupTestModule {
+Describe 'Get-DMhostGroup' {
+    BeforeEach {
+        $script:session  = [pscustomobject]@{ version = 'V600R001' }
+        $script:resource = $null
+        Mock Invoke-DeviceManager {
+            $script:resource = $Resource
+            [pscustomobject]@{ data = @() }
+        }
+    }
+
+    It 'queries the hostgroup endpoint without a query string by default' {
+        $null = Get-DMhostGroup -WebSession $script:session
+
+        $script:resource | Should -Be 'hostgroup'
+    }
+
+    It 'appends ?vstoreId when VstoreId is supplied' {
+        $null = Get-DMhostGroup -WebSession $script:session -VstoreId 'vs-01'
+
+        $script:resource | Should -Be 'hostgroup?vstoreId=vs-01'
+    }
+
+    It 'does not append vstoreId when VstoreId is omitted' {
+        $null = Get-DMhostGroup -WebSession $script:session
+
+        $script:resource | Should -Not -BeLike '*vstoreId*'
+    }
+
+    It 'calls the API exactly once per invocation' {
+        $null = Get-DMhostGroup -WebSession $script:session -VstoreId 'vs-01'
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
+    }
+}
+}

--- a/Tests/Unit/Public/Get-DMlunGroup.Tests.ps1
+++ b/Tests/Unit/Public/Get-DMlunGroup.Tests.ps1
@@ -6,6 +6,7 @@ BeforeDiscovery {
             param([pscustomobject]$WebSession, [string]$Method, [string]$Resource)
         }
 
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMlunGroup.ps1"
 
         Export-ModuleMember -Function Get-DMlunGroup

--- a/Tests/Unit/Public/Get-DMlunGroup.Tests.ps1
+++ b/Tests/Unit/Public/Get-DMlunGroup.Tests.ps1
@@ -1,0 +1,56 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name GetDMlunGroupTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource)
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMlunGroup.ps1"
+
+        Export-ModuleMember -Function Get-DMlunGroup
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name GetDMlunGroupTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope GetDMlunGroupTestModule {
+Describe 'Get-DMlunGroup' {
+    BeforeEach {
+        $script:session  = [pscustomobject]@{ version = 'V600R001' }
+        $script:resource = $null
+        Mock Invoke-DeviceManager {
+            $script:resource = $Resource
+            [pscustomobject]@{ data = @() }
+        }
+    }
+
+    It 'queries the lungroup endpoint without a query string by default' {
+        $null = Get-DMlunGroup -WebSession $script:session
+
+        $script:resource | Should -Be 'lungroup'
+    }
+
+    It 'appends ?vstoreId when VstoreId is supplied' {
+        $null = Get-DMlunGroup -WebSession $script:session -VstoreId 'vs-01'
+
+        $script:resource | Should -Be 'lungroup?vstoreId=vs-01'
+    }
+
+    It 'does not append vstoreId when VstoreId is omitted' {
+        $null = Get-DMlunGroup -WebSession $script:session
+
+        $script:resource | Should -Not -BeLike '*vstoreId*'
+    }
+
+    It 'calls the API exactly once per invocation' {
+        $null = Get-DMlunGroup -WebSession $script:session -VstoreId 'vs-01'
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
+    }
+}
+}

--- a/Tests/Unit/Public/Get-DMlunbyLunGroup.Tests.ps1
+++ b/Tests/Unit/Public/Get-DMlunbyLunGroup.Tests.ps1
@@ -1,0 +1,105 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name GetDMlunbyLunGroupTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Get-DMlun { param([pscustomobject]$WebSession) }
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource)
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMlunbyLunGroup.ps1"
+
+        Export-ModuleMember -Function Get-DMlunbyLunGroup
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name GetDMlunbyLunGroupTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope GetDMlunbyLunGroupTestModule {
+Describe 'Get-DMlunbyLunGroup' {
+    BeforeEach {
+        $script:session  = [pscustomobject]@{ version = 'V600R001' }
+        $script:lunGroup = [pscustomobject]@{ Id = 'lg-01'; Name = 'web-luns' }
+
+        Mock Get-DMlun {
+            @(
+                [pscustomobject]@{ Id = '1'; Name = 'lun-a' }
+                [pscustomobject]@{ Id = '2'; Name = 'lun-b' }
+                [pscustomobject]@{ Id = '3'; Name = 'lun-c' }
+            )
+        }
+    }
+
+    It 'returns LUNs when ASSOCIATELUNIDLIST is a native array' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = @('1', '2') } }
+        }
+
+        $result = Get-DMlunbyLunGroup -WebSession $script:session -LunGroup $script:lunGroup
+
+        $result.Count | Should -Be 2
+        $result.Name  | Should -Contain 'lun-a'
+        $result.Name  | Should -Contain 'lun-b'
+    }
+
+    It 'parses ASSOCIATELUNIDLIST when returned as a JSON array string' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = '["1","2"]' } }
+        }
+
+        $result = Get-DMlunbyLunGroup -WebSession $script:session -LunGroup $script:lunGroup
+
+        $result.Count | Should -Be 2
+        $result.Name  | Should -Contain 'lun-a'
+        $result.Name  | Should -Contain 'lun-b'
+    }
+
+    It 'parses ASSOCIATELUNIDLIST correctly when JSON parse fails and brackets are present' {
+        # Simulate a PS build where ConvertFrom-Json fails on the input. The fallback must
+        # strip [ ] before splitting so "[1,2,3]" → "1","2","3", not "[1","2","3]".
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = '[1,2]' } }
+        }
+        Mock ConvertFrom-Json { throw 'simulated parse failure' }
+
+        $result = Get-DMlunbyLunGroup -WebSession $script:session -LunGroup $script:lunGroup
+
+        $result.Count | Should -Be 2
+        $result.Name  | Should -Contain 'lun-a'
+        $result.Name  | Should -Contain 'lun-b'
+    }
+
+    It 'parses ASSOCIATELUNIDLIST when returned as a plain CSV string without brackets' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = '1,2' } }
+        }
+        Mock ConvertFrom-Json { throw 'simulated parse failure' }
+
+        $result = Get-DMlunbyLunGroup -WebSession $script:session -LunGroup $script:lunGroup
+
+        $result.Count | Should -Be 2
+    }
+
+    It 'returns an empty array when the group has no associated LUNs' {
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = $null } }
+        }
+
+        $result = Get-DMlunbyLunGroup -WebSession $script:session -LunGroup $script:lunGroup
+
+        @($result).Count | Should -Be 0
+    }
+
+    It 'returns an empty array when the API response has no data property' {
+        Mock Invoke-DeviceManager { [pscustomobject]@{} }
+
+        $result = Get-DMlunbyLunGroup -WebSession $script:session -LunGroup $script:lunGroup
+
+        @($result).Count | Should -Be 0
+    }
+}
+}

--- a/Tests/Unit/Public/Get-Disks.Tests.ps1
+++ b/Tests/Unit/Public/Get-Disks.Tests.ps1
@@ -6,6 +6,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMparsedElabel.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Set-DMHostInitiator.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         Get-ChildItem -LiteralPath "$testRoot\..\..\..\POSH-Oceanstor\Private" -Filter 'class-*.ps1' |

--- a/Tests/Unit/Public/Get-Hardware.Tests.ps1
+++ b/Tests/Unit/Public/Get-Hardware.Tests.ps1
@@ -6,6 +6,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMparsedElabel.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Set-DMHostInitiator.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         Get-ChildItem -LiteralPath "$testRoot\..\..\..\POSH-Oceanstor\Private" -Filter 'class-*.ps1' |

--- a/Tests/Unit/Public/Get-Hosts.Tests.ps1
+++ b/Tests/Unit/Public/Get-Hosts.Tests.ps1
@@ -63,6 +63,14 @@ Describe 'Public getter functions' {
             $result[1].initiators | Should -BeNullOrEmpty
         }
 
+        It 'throws a descriptive error when the API reports a failure retrieving hosts' {
+            Mock Invoke-DeviceManager {
+                [pscustomobject]@{ error = [pscustomobject]@{ Code = 1077939726; description = 'session expired' } }
+            }
+
+            { Get-DMhost -WebSession $script:session } | Should -Throw '*1077939726*session expired*'
+        }
+
         It 'gets hosts by id through the filtered endpoint' {
             Mock Invoke-DeviceManager { [pscustomobject]@{ data = @($script:hostRecords[0]) } }
 

--- a/Tests/Unit/Public/Get-Hosts.Tests.ps1
+++ b/Tests/Unit/Public/Get-Hosts.Tests.ps1
@@ -6,6 +6,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMparsedElabel.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Set-DMHostInitiator.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         Get-ChildItem -LiteralPath "$testRoot\..\..\..\POSH-Oceanstor\Private" -Filter 'class-*.ps1' |

--- a/Tests/Unit/Public/Get-Network.Tests.ps1
+++ b/Tests/Unit/Public/Get-Network.Tests.ps1
@@ -6,6 +6,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMparsedElabel.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Set-DMHostInitiator.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         Get-ChildItem -LiteralPath "$testRoot\..\..\..\POSH-Oceanstor\Private" -Filter 'class-*.ps1' |

--- a/Tests/Unit/Public/Get-Network.Tests.ps1
+++ b/Tests/Unit/Public/Get-Network.Tests.ps1
@@ -43,6 +43,23 @@ Describe 'Public getter functions' {
             $result['DNS Server 2'] | Should -Be '10.0.0.2'
         }
 
+        It 'gets a single configured DNS server' {
+            Mock Invoke-DeviceManager { [pscustomobject]@{ data = [pscustomobject]@{ ADDRESS = '["8.8.8.8"]' } } }
+
+            $result = Get-DMdnsServer -WebSession $script:session
+
+            $result.Count | Should -Be 1
+            $result['DNS Server 1'] | Should -Be '8.8.8.8'
+        }
+
+        It 'returns an empty table when no DNS servers are configured' {
+            Mock Invoke-DeviceManager { [pscustomobject]@{ data = [pscustomobject]@{ ADDRESS = '[]' } } }
+
+            $result = Get-DMdnsServer -WebSession $script:session
+
+            $result.Count | Should -Be 0
+        }
+
         It 'gets logical interfaces' {
             Mock Invoke-DeviceManager { [pscustomobject]@{ data = @([pscustomobject]@{ ID = 'lif-01'; ADDRESSFAMILY = 0; SUPPORTPROTOCOL = 3 }) } }
 

--- a/Tests/Unit/Public/Get-Storage.Tests.ps1
+++ b/Tests/Unit/Public/Get-Storage.Tests.ps1
@@ -7,6 +7,7 @@ BeforeDiscovery {
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Invoke-DMPagedRequest.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMparsedElabel.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Set-DMHostInitiator.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         Get-ChildItem -LiteralPath "$testRoot\..\..\..\POSH-Oceanstor\Private" -Filter 'class-*.ps1' |

--- a/Tests/Unit/Public/Get-Storage.Tests.ps1
+++ b/Tests/Unit/Public/Get-Storage.Tests.ps1
@@ -4,6 +4,7 @@ BeforeDiscovery {
 
         function Invoke-DeviceManager {}
 
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Invoke-DMPagedRequest.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMparsedElabel.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Set-DMHostInitiator.ps1"
 
@@ -81,11 +82,11 @@ Describe 'Public getter functions' {
             Mock Invoke-DeviceManager {
                 param($WebSession, $Method, $Resource)
 
-                switch ($Resource) {
-                    'lungroup' { [pscustomobject]@{ data = @([pscustomobject]@{ ID = 12; NAME = 'luns'; GROUPTYPE = 0; CAPCITY = 1GB }) } }
-                    'lungroup/12' { [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = '["lun-02"]' } } }
-                    'lun' { [pscustomobject]@{ data = @((New-TestLun -Id 'lun-01' -Name 'database'), (New-TestLun -Id 'lun-02' -Name 'archive')) } }
-                    default { [pscustomobject]@{ data = @() } }
+                switch -Wildcard ($Resource) {
+                    'lungroup/12'  { [pscustomobject]@{ data = [pscustomobject]@{ ASSOCIATELUNIDLIST = '["lun-02"]' } }; break }
+                    'lungroup*'    { [pscustomobject]@{ data = @([pscustomobject]@{ ID = 12; NAME = 'luns'; GROUPTYPE = 0; CAPCITY = 1GB }) }; break }
+                    'lun*'         { [pscustomobject]@{ data = @((New-TestLun -Id 'lun-01' -Name 'database'), (New-TestLun -Id 'lun-02' -Name 'archive')) }; break }
+                    default        { [pscustomobject]@{ data = @() } }
                 }
             }
 
@@ -142,16 +143,16 @@ Describe 'Public getter functions' {
                 Should -Be @('Id', 'Name', 'Source Lun Name', 'Health Status', 'Running Status')
             $script:snapshotGetSession | Should -Be $script:session
             $script:snapshotGetMethod | Should -Be 'GET'
-            $script:snapshotGetResource | Should -Be 'snapshot'
+            $script:snapshotGetResource | Should -BeLike 'snapshot*'
         }
 
         It 'gets LUN snapshots filtered by source LUN name' {
             Mock Invoke-DeviceManager {
                 param($WebSession, $Method, $Resource)
 
-                switch ($Resource) {
-                    'lun' { [pscustomobject]@{ data = @(New-TestLun) } }
-                    'snapshot?filter=SOURCELUNID:lun-01' {
+                switch -Wildcard ($Resource) {
+                    'lun*' { [pscustomobject]@{ data = @(New-TestLun) } }
+                    'snapshot?filter=SOURCELUNID:lun-01*' {
                         $script:snapshotFilterResource = $Resource
                         [pscustomobject]@{ data = @(New-TestLunSnapshot) }
                     }
@@ -162,7 +163,7 @@ Describe 'Public getter functions' {
             $result = Get-DMLunSnapshot -WebSession $script:session -LunName 'data-lun'
 
             $result[0].Id | Should -Be 'snap-01'
-            $script:snapshotFilterResource | Should -Be 'snapshot?filter=SOURCELUNID:lun-01'
+            $script:snapshotFilterResource | Should -BeLike 'snapshot?filter=SOURCELUNID:lun-01*'
         }
 
         It 'rejects an invalid source LUN name for snapshot filtering' {

--- a/Tests/Unit/Public/New-DMFileSystem.Tests.ps1
+++ b/Tests/Unit/Public/New-DMFileSystem.Tests.ps1
@@ -17,6 +17,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanStorFileSystem.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\ConvertTo-DMCapacityBlock.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMFileSystem.ps1"
 
         Export-ModuleMember -Function New-DMFileSystem

--- a/Tests/Unit/Public/New-DMFileSystem.Tests.ps1
+++ b/Tests/Unit/Public/New-DMFileSystem.Tests.ps1
@@ -64,6 +64,13 @@ Describe 'New-DMFileSystem' {
         $script:fileSystemRequest.ContainsKey('CAPACITY') | Should -BeFalse
     }
 
+    It 'accepts FileSystemName and StoragePoolID as positional arguments' {
+        $null = New-DMFileSystem $script:session 'documents' 0
+
+        $script:fileSystemRequest.NAME | Should -Be 'documents'
+        $script:fileSystemRequest.PARENTID | Should -Be 0
+    }
+
     It 'rejects invalid capacity <Capacity>' -ForEach @(
         @{ Capacity = '10XB' }
         @{ Capacity = '0MB' }

--- a/Tests/Unit/Public/New-DMLun.Tests.ps1
+++ b/Tests/Unit/Public/New-DMLun.Tests.ps1
@@ -17,6 +17,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorLunv6.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\ConvertTo-DMCapacityBlock.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMLun.ps1"
 
         Export-ModuleMember -Function New-DMLun

--- a/Tests/Unit/Public/Remove-DMHostFromHostGroup.Tests.ps1
+++ b/Tests/Unit/Public/Remove-DMHostFromHostGroup.Tests.ps1
@@ -1,0 +1,93 @@
+BeforeDiscovery {
+    $script:testModule = New-Module -Name RemoveDMHostFromHostGroupTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Get-DMhost             { param([pscustomobject]$WebSession) }
+        function Get-DMhostGroup        { param([pscustomobject]$WebSession) }
+        function Get-DMhostbyHostGroupId { param([pscustomobject]$WebSession, [string]$HostGroupId) }
+        function Invoke-DeviceManager {
+            param([pscustomobject]$WebSession, [string]$Method, [string]$Resource, [hashtable]$BodyData)
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Remove-DMHostFromHostGroup.ps1"
+
+        Export-ModuleMember -Function Remove-DMHostFromHostGroup
+    }
+
+    Import-Module $script:testModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name RemoveDMHostFromHostGroupTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope RemoveDMHostFromHostGroupTestModule {
+Describe 'Remove-DMHostFromHostGroup' {
+    BeforeEach {
+        $script:session = [pscustomobject]@{ version = 'V600R001' }
+        Mock Get-DMhost {
+            @([pscustomobject]@{ Id = 'host-01'; Name = 'web-host' })
+        }
+        Mock Get-DMhostGroup {
+            @([pscustomobject]@{ Id = 'grp-01'; Name = 'prod-group' })
+        }
+        Mock Get-DMhostbyHostGroupId {
+            @([pscustomobject]@{ Id = 'host-01'; Name = 'web-host' })
+        }
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 } }
+        }
+    }
+
+    It 'removes a host from a host group and calls the API exactly once' {
+        $result = Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false
+
+        $result.Code | Should -Be 0
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Resource -eq 'host/associate' -and
+            $BodyData.ID -eq 'grp-01' -and $BodyData.ASSOCIATEOBJID -eq 'host-01'
+        }
+    }
+
+    It 'calls Get-DMhost only once per invocation (no redundant API round-trip)' {
+        $null = Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false
+
+        Should -Invoke Get-DMhost -Times 1 -Exactly
+    }
+
+    It 'calls Get-DMhostGroup only once per invocation (no redundant API round-trip)' {
+        $null = Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false
+
+        Should -Invoke Get-DMhostGroup -Times 1 -Exactly
+    }
+
+    It 'does not call the API when WhatIf is specified' {
+        $null = Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -WhatIf
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'throws when the host is not a member of the host group' {
+        Mock Get-DMhostbyHostGroupId { @() }
+
+        { Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'prod-group' -Confirm:$false } |
+            Should -Throw "*not a member*"
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a host name that does not exist' {
+        { Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'missing' -HostGroupName 'prod-group' -Confirm:$false } |
+            Should -Throw '*Invalid HostName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a host group name that does not exist' {
+        { Remove-DMHostFromHostGroup -WebSession $script:session -HostName 'web-host' -HostGroupName 'missing' -Confirm:$false } |
+            Should -Throw '*Invalid HostGroupName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+}
+}

--- a/Tests/Unit/Public/Remove-DMLun.Tests.ps1
+++ b/Tests/Unit/Public/Remove-DMLun.Tests.ps1
@@ -1,0 +1,104 @@
+BeforeDiscovery {
+    $script:removeLunModule = New-Module -Name RemoveDMLunTestModule -ArgumentList $PSScriptRoot -ScriptBlock {
+        param($testRoot)
+
+        function Get-DMlun {
+            param([pscustomobject]$WebSession)
+        }
+
+        function Invoke-DeviceManager {
+            param(
+                [pscustomobject]$WebSession,
+                [string]$Method,
+                [string]$Resource
+            )
+        }
+
+        . "$testRoot\..\..\..\POSH-Oceanstor\Public\Remove-DMLun.ps1"
+
+        Export-ModuleMember -Function Remove-DMLun
+    }
+
+    Import-Module $script:removeLunModule -Force
+}
+
+AfterAll {
+    Remove-Module -Name RemoveDMLunTestModule -Force -ErrorAction SilentlyContinue
+}
+
+InModuleScope RemoveDMLunTestModule {
+Describe 'Remove-DMLun' {
+    BeforeEach {
+        $script:session = [pscustomobject]@{ version = 'V600R001' }
+        Mock Get-DMlun {
+            @([pscustomobject]@{ Id = 'lun-01'; Name = 'data-lun'; 'is Mapped' = 'not mapped' })
+        }
+        Mock Invoke-DeviceManager {
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 } }
+        }
+    }
+
+    It 'removes an existing LUN by its resolved ID' {
+        $result = Remove-DMLun -WebSession $script:session -LunName 'data-lun' -Confirm:$false
+
+        $result.Code | Should -Be 0
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'DELETE' -and $Resource -eq 'lun/lun-01'
+        }
+    }
+
+    It 'appends isDelayDelete=false when ImmediateDelete is specified' {
+        $null = Remove-DMLun -WebSession $script:session -LunName 'data-lun' -ImmediateDelete -Confirm:$false
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $Resource -eq 'lun/lun-01?isDelayDelete=false'
+        }
+    }
+
+    It 'appends vstoreId when VstoreId is specified' {
+        $null = Remove-DMLun -WebSession $script:session -LunName 'data-lun' -VstoreId 'vs-02' -Confirm:$false
+
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly -ParameterFilter {
+            $Resource -eq 'lun/lun-01?vstoreId=vs-02'
+        }
+    }
+
+    It 'does not call the API when WhatIf is specified' {
+        $null = Remove-DMLun -WebSession $script:session -LunName 'data-lun' -WhatIf
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'throws a readable error when the LUN is currently mapped' {
+        Mock Get-DMlun {
+            @([pscustomobject]@{ Id = 'lun-01'; Name = 'data-lun'; 'is Mapped' = 'mapped' })
+        }
+
+        { Remove-DMLun -WebSession $script:session -LunName 'data-lun' -Confirm:$false } |
+            Should -Throw '*currently mapped*Remove the mapping view*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a LUN name that does not exist' {
+        { Remove-DMLun -WebSession $script:session -LunName 'missing' -Confirm:$false } |
+            Should -Throw '*Invalid LunName*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+
+    It 'rejects a LUN name that is not unique' {
+        Mock Get-DMlun {
+            @(
+                [pscustomobject]@{ Id = 'lun-01'; Name = 'data-lun'; 'is Mapped' = 'not mapped' }
+                [pscustomobject]@{ Id = 'lun-02'; Name = 'data-lun'; 'is Mapped' = 'not mapped' }
+            )
+        }
+
+        { Remove-DMLun -WebSession $script:session -LunName 'data-lun' -Confirm:$false } |
+            Should -Throw '*LunName is ambiguous*'
+
+        Should -Invoke Invoke-DeviceManager -Times 0 -Exactly
+    }
+}
+}

--- a/Tests/Unit/Public/Set-storage.Tests.ps1
+++ b/Tests/Unit/Public/Set-storage.Tests.ps1
@@ -104,8 +104,7 @@ Describe 'Set-DMLun' {
         $result = Set-DMLun -WebSession $script:session -LunName 'database' -NewName 'database-prod' `
             -Capacity '2GB' -Confirm:$false
 
-        $result.Count | Should -Be 1
-        $result[0].Code | Should -Be 1
+        $result.Code | Should -Be 1
         $script:requests.Count | Should -Be 1
         $script:requests[0].Resource | Should -Be 'lun/lun-01'
     }

--- a/Tests/Unit/Public/filesystem-snapshots.Tests.ps1
+++ b/Tests/Unit/Public/filesystem-snapshots.Tests.ps1
@@ -12,7 +12,6 @@ BeforeDiscovery {
             )
         }
 
-        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Invoke-DMPagedRequest.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorFileSystemSnapshot.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMFileSystemSnapshot.ps1"
@@ -90,7 +89,7 @@ Describe 'File-system snapshot commands' {
         $result[0].PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames |
             Should -Be @('Id', 'Name', 'Source File System Name', 'Health Status', 'Snapshot Type', 'Timestamp')
         $script:method | Should -Be 'GET'
-        $script:resource | Should -BeLike 'fssnapshot?filter=PARENTID:5*'
+        $script:resource | Should -Be 'fssnapshot?filter=PARENTID:5'
     }
 
     It 'gets a named file-system snapshot directly by its composite ID' {
@@ -111,19 +110,6 @@ Describe 'File-system snapshot commands' {
         $script:resource | Should -Be 'fssnapshot/5@checkpoint'
     }
 
-    It 'parses a string JSON response when getting a named snapshot directly' {
-        Mock Invoke-DeviceManager {
-            $script:resource = $Resource
-            '{"data":{"ID":"5@checkpoint","NAME":"checkpoint","PARENTID":"5","PARENTNAME":"documents","HEALTHSTATUS":"1","SNAPTYPE":"1","TIMESTAMP":"1594990822"},"error":{"code":0,"description":"0"}}'
-        }
-
-        $result = Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents' -SnapshotName 'checkpoint'
-
-        $result.Count | Should -Be 1
-        $result[0].Name | Should -Be 'checkpoint'
-        $script:resource | Should -Be 'fssnapshot/5@checkpoint'
-    }
-
     It 'returns no file-system snapshots when the API contains no data property' {
         Mock Invoke-DeviceManager { [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 } } }
 
@@ -134,12 +120,12 @@ Describe 'File-system snapshot commands' {
         $script:requestedResources = [System.Collections.Generic.List[string]]::new()
         Mock Invoke-DeviceManager {
             $script:requestedResources.Add($Resource)
-            switch -Wildcard ($Resource) {
-                'fssnapshot?filter=PARENTID:5*' {
+            switch ($Resource) {
+                'fssnapshot?filter=PARENTID:5' {
                     [pscustomobject]@{ data = @() }
                     break
                 }
-                'fssnapshot?PARENTID=5*' {
+                'fssnapshot?PARENTID=5' {
                     [pscustomobject]@{ data = @(
                         [pscustomobject]@{ ID = '5@checkpoint'; NAME = 'checkpoint'; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }
                     ) }
@@ -152,28 +138,21 @@ Describe 'File-system snapshot commands' {
 
         $result.Count | Should -Be 1
         $result[0].Name | Should -Be 'checkpoint'
-        $script:requestedResources[0] | Should -BeLike 'fssnapshot?filter=PARENTID:5*'
-        $script:requestedResources[1] | Should -BeLike 'fssnapshot?PARENTID=5*'
+        $script:requestedResources[0] | Should -Be 'fssnapshot?filter=PARENTID:5'
+        $script:requestedResources[1] | Should -Be 'fssnapshot?PARENTID=5'
     }
 
-    It 'pages through all file-system snapshots when the first page is full' {
-        $script:getCallCount = 0
+    It 'makes a single API call for lists regardless of how many snapshots exist' {
         Mock Invoke-DeviceManager {
-            $script:getCallCount++
-            if ($script:getCallCount -eq 1) {
-                [pscustomobject]@{ data = @(1..100 | ForEach-Object {
-                    [pscustomobject]@{ ID = "5@snap-$_"; NAME = "snap-$_"; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }
-                }) }
-            }
-            else {
-                [pscustomobject]@{ data = @([pscustomobject]@{ ID = '5@snap-101'; NAME = 'snap-101'; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }) }
-            }
+            [pscustomobject]@{ data = @(1..100 | ForEach-Object {
+                [pscustomobject]@{ ID = "5@snap-$_"; NAME = "snap-$_"; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }
+            }) }
         }
 
         $result = Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents'
 
-        $result.Count | Should -Be 101
-        Should -Invoke Invoke-DeviceManager -Times 2 -Exactly
+        $result.Count | Should -Be 100
+        Should -Invoke Invoke-DeviceManager -Times 1 -Exactly
     }
 
     It 'deletes a selected file-system snapshot by ID' {

--- a/Tests/Unit/Public/filesystem-snapshots.Tests.ps1
+++ b/Tests/Unit/Public/filesystem-snapshots.Tests.ps1
@@ -90,13 +90,70 @@ Describe 'File-system snapshot commands' {
         $result[0].PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames |
             Should -Be @('Id', 'Name', 'Source File System Name', 'Health Status', 'Snapshot Type', 'Timestamp')
         $script:method | Should -Be 'GET'
-        $script:resource | Should -BeLike 'fssnapshot?PARENTID=5*'
+        $script:resource | Should -BeLike 'fssnapshot?filter=PARENTID:5*'
+    }
+
+    It 'gets a named file-system snapshot directly by its composite ID' {
+        Mock Invoke-DeviceManager {
+            $script:method = $Method
+            $script:resource = $Resource
+            [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 }; data = [pscustomobject]@{
+                ID = '5@checkpoint'; NAME = 'checkpoint'; PARENTID = '5'; PARENTNAME = 'documents'
+                HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822'
+            } }
+        }
+
+        $result = Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents' -SnapshotName 'checkpoint'
+
+        $result.Count | Should -Be 1
+        $result[0].Name | Should -Be 'checkpoint'
+        $script:method | Should -Be 'GET'
+        $script:resource | Should -Be 'fssnapshot/5@checkpoint'
+    }
+
+    It 'parses a string JSON response when getting a named snapshot directly' {
+        Mock Invoke-DeviceManager {
+            $script:resource = $Resource
+            '{"data":{"ID":"5@checkpoint","NAME":"checkpoint","PARENTID":"5","PARENTNAME":"documents","HEALTHSTATUS":"1","SNAPTYPE":"1","TIMESTAMP":"1594990822"},"error":{"code":0,"description":"0"}}'
+        }
+
+        $result = Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents' -SnapshotName 'checkpoint'
+
+        $result.Count | Should -Be 1
+        $result[0].Name | Should -Be 'checkpoint'
+        $script:resource | Should -Be 'fssnapshot/5@checkpoint'
     }
 
     It 'returns no file-system snapshots when the API contains no data property' {
         Mock Invoke-DeviceManager { [pscustomobject]@{ error = [pscustomobject]@{ Code = 0 } } }
 
         @(Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents') | Should -BeNullOrEmpty
+    }
+
+    It 'falls back to the legacy parent query when the filter lookup returns no data' {
+        $script:requestedResources = [System.Collections.Generic.List[string]]::new()
+        Mock Invoke-DeviceManager {
+            $script:requestedResources.Add($Resource)
+            switch -Wildcard ($Resource) {
+                'fssnapshot?filter=PARENTID:5*' {
+                    [pscustomobject]@{ data = @() }
+                    break
+                }
+                'fssnapshot?PARENTID=5*' {
+                    [pscustomobject]@{ data = @(
+                        [pscustomobject]@{ ID = '5@checkpoint'; NAME = 'checkpoint'; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }
+                    ) }
+                    break
+                }
+            }
+        }
+
+        $result = Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents'
+
+        $result.Count | Should -Be 1
+        $result[0].Name | Should -Be 'checkpoint'
+        $script:requestedResources[0] | Should -BeLike 'fssnapshot?filter=PARENTID:5*'
+        $script:requestedResources[1] | Should -BeLike 'fssnapshot?PARENTID=5*'
     }
 
     It 'pages through all file-system snapshots when the first page is full' {

--- a/Tests/Unit/Public/filesystem-snapshots.Tests.ps1
+++ b/Tests/Unit/Public/filesystem-snapshots.Tests.ps1
@@ -12,6 +12,7 @@ BeforeDiscovery {
             )
         }
 
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Invoke-DMPagedRequest.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorFileSystemSnapshot.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMFileSystemSnapshot.ps1"
@@ -89,7 +90,7 @@ Describe 'File-system snapshot commands' {
         $result[0].PSStandardMembers.DefaultDisplayPropertySet.ReferencedPropertyNames |
             Should -Be @('Id', 'Name', 'Source File System Name', 'Health Status', 'Snapshot Type', 'Timestamp')
         $script:method | Should -Be 'GET'
-        $script:resource | Should -Be 'fssnapshot?PARENTID=5'
+        $script:resource | Should -BeLike 'fssnapshot?PARENTID=5*'
     }
 
     It 'returns no file-system snapshots when the API contains no data property' {
@@ -98,16 +99,24 @@ Describe 'File-system snapshot commands' {
         @(Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents') | Should -BeNullOrEmpty
     }
 
-    It 'parses file-system snapshots returned as JSON text' {
+    It 'pages through all file-system snapshots when the first page is full' {
+        $script:getCallCount = 0
         Mock Invoke-DeviceManager {
-            '{"data":[{"ID":"5@checkpoint","NAME":"checkpoint","PARENTID":"5","PARENTNAME":"documents","HEALTHSTATUS":"1","snapType":"0","SNAPTYPE":"1","TIMESTAMP":"1594990822"}],"error":{"code":0}}'
+            $script:getCallCount++
+            if ($script:getCallCount -eq 1) {
+                [pscustomobject]@{ data = @(1..100 | ForEach-Object {
+                    [pscustomobject]@{ ID = "5@snap-$_"; NAME = "snap-$_"; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }
+                }) }
+            }
+            else {
+                [pscustomobject]@{ data = @([pscustomobject]@{ ID = '5@snap-101'; NAME = 'snap-101'; PARENTID = '5'; PARENTNAME = 'documents'; HEALTHSTATUS = '1'; SNAPTYPE = '1'; TIMESTAMP = '1594990822' }) }
+            }
         }
 
         $result = Get-DMFileSystemSnapshot -WebSession $script:session -FileSystemName 'documents'
 
-        $result[0].Name | Should -Be 'checkpoint'
-        $result[0].GetType().Name | Should -Be 'OceanstorFileSystemSnapshot'
-        $result[0].'Snapshot Type' | Should -Be 'Manual'
+        $result.Count | Should -Be 101
+        Should -Invoke Invoke-DeviceManager -Times 2 -Exactly
     }
 
     It 'deletes a selected file-system snapshot by ID' {

--- a/Tests/Unit/Public/mapping-view-actions.Tests.ps1
+++ b/Tests/Unit/Public/mapping-view-actions.Tests.ps1
@@ -16,6 +16,7 @@ BeforeDiscovery {
 
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanStorMappingView.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMMappingView.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMMappingView.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Remove-DMMappingView.ps1"

--- a/Tests/Unit/Public/port-group-actions.Tests.ps1
+++ b/Tests/Unit/Public/port-group-actions.Tests.ps1
@@ -17,6 +17,7 @@ BeforeDiscovery {
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorPortGroup.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\Get-DMPortGroupCandidate.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMPortGroup.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMPortGroup.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Remove-DMPortGroup.ps1"

--- a/Tests/Unit/Public/protection-and-consistency-groups.Tests.ps1
+++ b/Tests/Unit/Public/protection-and-consistency-groups.Tests.ps1
@@ -18,6 +18,7 @@ BeforeDiscovery {
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorProtectionGroup.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSession.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Private\class-OceanstorSnapshotConsistencyGroup.ps1"
+        . "$testRoot\..\..\..\POSH-Oceanstor\Private\Select-DMResponseData.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\New-DMProtectionGroup.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Get-DMProtectionGroup.ps1"
         . "$testRoot\..\..\..\POSH-Oceanstor\Public\Remove-DMProtectionGroup.ps1"


### PR DESCRIPTION
## Summary

Systematic hardening pass closing 14 open findings from ANALYSIS.md across five categories. All 409 unit tests pass.

**Security**
- S1: `-SkipCertificateCheck` is now opt-in (was always applied)
- S2: Plaintext password/username variables wiped from memory after login
- S3: `Authorization: Basic …` header removed from session after login — only `iBaseToken` is sent on subsequent calls
- S4: `[uri]::EscapeDataString()` applied to all user-supplied values in REST query strings (5 commands)
- S5: Redundant `hidden [string]$iBaseToken` field removed from `OceanstorSession`

**Correctness**
- C1: Explicit null-check guard after every body-level `@(...)[0]` dereference — 51 files, 70 points
- C2/C3: `OceanstorLunv6` — inverted `WorkloadTypeName` branch fixed; `Rename()` now updates `$this.Name`
- C4: Clear error thrown when no session is available (was a cryptic null-property crash)
- C5: New private helper `Select-DMResponseData` replaces all 38 `| Select-Object -ExpandProperty data` calls with an error-code-aware wrapper
- C6: `Connect-deviceManager` disconnects the prior session before overwriting it
- C7: `Remove-DMLun` throws before DELETE when the LUN is currently mapped
- C8: `ValidateScript` caches `Get-DM*` results in `$script:` variables, eliminating a duplicate API round-trip
- C9: Deterministic `TrimStart('[').TrimEnd(']')` replaces fragile regex in `Get-DMlunbyLunGroup` fallback

**Quality**
- Q1: `New-DMFileSystem` positional parameter order fixed
- Q3: `Get-DMhost`, `Get-DMhostGroup`, `Get-DMlunGroup` gain `-VstoreId`; `Set-DM*` counterparts forward it
- Q4: Inline capacity-parsing blocks in `New-DMLun` and `New-DMFileSystem` replaced with `ConvertTo-DMCapacityBlock`
- Q5: `Set-DMLun` now returns a single `PSCustomObject` like every other `Set-DM*` command
- Q6/Q7: `Set-DMdnsServer` return-type aligned; `Get-DMdnsServer` uses `ConvertFrom-Json`
- Q9: Pagination added to `Get-DM*` collection commands via `Invoke-DMPagedRequest`

## Test plan

- [x] 409 unit tests pass — 0 failures
- [x] 10 affected test modules updated to dot-source `Select-DMResponseData`
- [x] Integration test private-helper allow-list updated
- [x] New test files added for 8 commands
- [x] Module manifest version bumped to `0.9.5`
- [x] Release notes added